### PR TITLE
Add authentication via API token

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,13 +21,16 @@ class ApplicationController < ActionController::Base
   def current_user
     return @current_user if @current_user
 
+    # if an API key parameter was given, try to auth with that.
+    if params[:api_key]
+      return (@current_user = User.find_by_key(params[:api_key]))
+    end
+
     # we only load the user from a session cookie if we're using the same
     # database we were using when the cookie was issued
     if session[:db_sig] == DatabaseSignature.generate
-      @current_user = User.find_by_id(session[:user_id])
+      return (@current_user = User.find_by_id(session[:user_id]))
     end
-
-    return @current_user
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,7 +14,7 @@
 
 class UsersController < ApplicationController
   # Updating an account is only allowed with the password auth system.
-  before_filter :require_password_auth, :except => :show
+  before_filter :require_password_auth, :except => [:show, :reset_key]
 
   private
 
@@ -52,6 +52,19 @@ class UsersController < ApplicationController
         format.html { redirect_to account_path, :notice => 'Account was successfully updated.' }
       else
         format.html { render :action => "edit" }
+      end
+    end
+  end
+
+  # POST /account/reset_key
+  def reset_key
+    current_user.generate_key
+
+    respond_to do |format|
+      if current_user.save
+        format.html { redirect_to account_path, :notice => 'Your API key has been reset.' }
+      else
+        format.html { redirect_to account_path, :error => 'Could not reset API key.' }
       end
     end
   end

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -27,6 +27,13 @@
   %span.email= current_user.email
 
 %p
+  %b API Key:
+  %span.apikey= current_user.key
+  = link_to 'Reset', reset_key_path,
+          :class => 'btn btn-danger btn-mini', :method => 'post',
+          :confirm => "Are you sure? You will no longer be able to perform API requests with your old key."
+
+%p
   %b Privileged:
   %span.priv= current_user.privileged? ? 'Yes' : 'No'
   %a{:href => '#', :rel => 'tooltip', :title => "Privileged users can submit production jobs that cost money. Unprivileged users can submit sandbox jobs, and can create production jobs and ask a privileged user to submit the job."}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,7 @@ ClockworkRaven::Application.routes.draw do
   get 'account' => 'users#show', :as => 'account'
   get 'account/edit' => 'users#edit', :as => 'edit_account'
   put 'account' => 'users#update', :as => 'update_account'
+  post 'account/reset_key' => 'users#reset_key', :as => 'reset_key'
 
   # default: /evaluations
   root :to => 'evaluations#index'

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -106,7 +106,7 @@ END_S
       menu.header = "Successfully created user \"#{username}\""
       menu.prompt = 'Show API key? '
       menu.choice('yes') { puts "The user's API key is #{user.key}" }
-      menu.choice('no')  {                                               }
+      menu.choice('no')  {                                          }
     end
 
     @in.choose do |menu|
@@ -136,7 +136,7 @@ END_S
       menu.header = "Successfully changed password for \"#{username}\""
       menu.prompt = 'Change another? '
       menu.choice('yes') { change_password }
-      menu.choice('no')  {     }
+      menu.choice('no')  {                 }
     end
   end
 
@@ -152,7 +152,7 @@ END_S
 
         puts "\nAPI keys have been reset."
       end
-      menu.choice('no')  {     }
+      menu.choice('no') {}
     end
   end
 

--- a/test/functional/controllers/logins_controller_test.rb
+++ b/test/functional/controllers/logins_controller_test.rb
@@ -20,6 +20,7 @@ class NonLoginsControllerTest < ActionController::TestCase
 
   setup do
     @user = create :user
+    session.clear
   end
 
   test "no credentials" do
@@ -56,10 +57,24 @@ class NonLoginsControllerTest < ActionController::TestCase
     assert_forbidden
   end
 
-  test "valid" do
+  test "valid user id" do
     user = create :user
     session[:db_sig] = DatabaseSignature.generate
     session[:user_id] = user.id
+
+    get :index
+    assert_response :success
+  end
+
+  test "invalid api key" do
+    user = create :user
+    get :index, :api_key => 'wrong'
+    assert_forbidden
+  end
+
+  test "valid api key" do
+    user = create :user
+    get :index, :api_key => user.key
 
     get :index
     assert_response :success

--- a/test/functional/controllers/users_controller_test.rb
+++ b/test/functional/controllers/users_controller_test.rb
@@ -100,4 +100,14 @@ class UsersControllerTest < ActionController::TestCase
       assert_validations_fail :password => '1', :password_confirmation => ''
     end
   end
+
+  test "reset_key" do
+    old_key = @controller.current_user.key
+
+    post :reset_key
+
+    @controller.current_user.reload
+    assert_not_nil @controller.current_user.key
+    assert_not_equal old_key, @controller.current_user.key
+  end
 end

--- a/test/functional/views/users/show_test.rb
+++ b/test/functional/views/users/show_test.rb
@@ -26,6 +26,7 @@ class UsersShowTest < ActionController::TestCase
     assert_select "span.username:content('#{@user.username}')"
     assert_select "span.realname:content('#{@user.name}')"
     assert_select "span.email:content('#{@user.email}')"
+    assert_select "span.apikey:content('#{@user.key}')"
     assert_select "span.priv:content('No')"
   end
 


### PR DESCRIPTION
- Display API key in "my account" page. Add view test for this.
- Provide button to reset API key. Add controller test for the action that does this.
- Provide rake task users:reset_keys that resets all API keys
- Modify auth code to allow users to authenticate by passing an "api_key" parameter.
