### PR TITLE
Minor fixes to the evaluation form

### DIFF
--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -233,6 +233,24 @@ class Evaluation < ActiveRecord::Base
     return e
   end
 
+  # Creates accessors for time fields that convert from seconds to minutes
+  # These fields are accessible through :field_in_minutes
+  def self.minutes_accessor(*args)
+    args.each do |a|
+      class_eval do
+        name = a.to_s + "_in_minutes"
+        define_method(name) { self[a] / 60 }
+        define_method(name + "=") { |min| self[a] = min.to_i * 60}
+      end
+    end
+  end
+
+  minutes_accessor :duration, :lifetime, :auto_approve
+
+  def duration_in_minutes=(minutes)
+    self.duration = minutes.to_i * 60
+  end
+
   # Registers this evaluation as a HIT Type on MTurk, then submits all
   # of this evaluation's tasks as HITs. Tasks are submitted in the background.
   # Returns the Job corresponding to submitting the tasks.

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -141,6 +141,20 @@ class Evaluation < ActiveRecord::Base
 
   validates :mturk_qualification, :inclusion => { :in => %w(none trusted master) }
 
+  # Creates accessors for time fields that converts between seconds and minutes
+  # These fields are accessible through :field_in_minutes
+  def self.minutes_accessor(*args)
+    args.each do |a|
+      class_eval do
+        name = a.to_s + "_in_minutes"
+        define_method(name) { self[a] / 60 }
+        define_method(name + "=") { |min| self[a] = min.to_i * 60 }
+      end
+    end
+  end
+
+  minutes_accessor :duration, :lifetime, :auto_approve
+
   # Given an array of objects, add a Task to this evaluation for each element
   # of the array
   #
@@ -231,24 +245,6 @@ class Evaluation < ActiveRecord::Base
     end
 
     return e
-  end
-
-  # Creates accessors for time fields that convert from seconds to minutes
-  # These fields are accessible through :field_in_minutes
-  def self.minutes_accessor(*args)
-    args.each do |a|
-      class_eval do
-        name = a.to_s + "_in_minutes"
-        define_method(name) { self[a] / 60 }
-        define_method(name + "=") { |min| self[a] = min.to_i * 60}
-      end
-    end
-  end
-
-  minutes_accessor :duration, :lifetime, :auto_approve
-
-  def duration_in_minutes=(minutes)
-    self.duration = minutes.to_i * 60
   end
 
   # Registers this evaluation as a HIT Type on MTurk, then submits all

--- a/app/views/evaluations/_form.html.haml
+++ b/app/views/evaluations/_form.html.haml
@@ -125,9 +125,8 @@
       %span.label-help Amount payed to MTurk workers for each task, in cents
     .controls
       .input-prepend
-        %span.add-on
-          $0.
         = f.number_field :payment
+        %span.add-on &cent;
 
   .control-group
     %label.control-label{:for => 'evaluation_duration'}

--- a/app/views/evaluations/_form.html.haml
+++ b/app/views/evaluations/_form.html.haml
@@ -134,11 +134,11 @@
         Duration
       %br
       %span.label-help
-        Amount of time, in seconds, a worker has to complete this task before
+        Amount of time, in minutes, a worker has to complete this task before
         it can be given to someone else
     .controls
       .input-append
-        = f.number_field :duration
+        = f.number_field :duration_in_minutes
         = render :partial => 'time_buttons'
 
   .control-group
@@ -147,11 +147,11 @@
         Lifetime
       %br
       %span.label-help
-        Amount of time, in seconds, this evaluation will be available on MTurk
+        Amount of time, in minutes, this evaluation will be available on MTurk
         after it is submitted
     .controls
       .input-append
-        = f.number_field :lifetime
+        = f.number_field :lifetime_in_minutes
         = render :partial => 'time_buttons'
 
   .control-group
@@ -161,11 +161,11 @@
       %br
       %span.label-help
         Tasks will be automatically approved after this amount of time, in
-        seconds, unless you explicitly approve or reject the worker's
+        minutes, unless you explicitly approve or reject the worker's
         response
     .controls
       .input-append
-        = f.number_field :auto_approve
+        = f.number_field :auto_approve_in_minutes
         = render :partial => 'time_buttons'
 
   .form-actions

--- a/app/views/evaluations/_time_buttons.html.haml
+++ b/app/views/evaluations/_time_buttons.html.haml
@@ -12,6 +12,6 @@
 -# See the License for the specific language governing permissions and
 -# limitations under the License.
 
-%button.btn.btn-time{:type => 'button', 'data-time' => '3600'} 1 Hour
-%button.btn.btn-time{:type => 'button', 'data-time' => '86400'} 1 Day
-%button.btn.btn-time{:type => 'button', 'data-time' => '604800'} 1 Week
+%button.btn.btn-time{:type => 'button', 'data-time' => '60'} 1 Hour
+%button.btn.btn-time{:type => 'button', 'data-time' => '1440'} 1 Day
+%button.btn.btn-time{:type => 'button', 'data-time' => '10080'} 1 Week

--- a/lib/m_turk_utils.rb
+++ b/lib/m_turk_utils.rb
@@ -234,7 +234,7 @@ module MTurkUtils
           question_response = response.fr_question_responses.build
 
           if answer_content.blank?
-            answer_content = "No reponse given"
+            answer_content = "No response given"
           end
 
           question_response.response = answer_content

--- a/test/unit/processors/close_processor_test.rb
+++ b/test/unit/processors/close_processor_test.rb
@@ -164,7 +164,7 @@ class CloseProcessorTest < ActiveSupport::TestCase
                                            first.id
     ).first
 
-    # free-reponse questions
+    # free-response questions
     assert_not_nil FRQuestionResponse.where(
       :task_response_id => response_1.id,
       :fr_question_id => fr1.id,
@@ -218,7 +218,7 @@ class CloseProcessorTest < ActiveSupport::TestCase
                                            first.id
     ).first
 
-    # free-reponse questions
+    # free-response questions
     assert_not_nil FRQuestionResponse.where(
       :task_response_id => response_2.id,
       :fr_question_id => fr1.id,
@@ -272,7 +272,7 @@ class CloseProcessorTest < ActiveSupport::TestCase
                                            first.id
     ).first
 
-    # free-reponse questions
+    # free-response questions
     assert_not_nil FRQuestionResponse.where(
       :task_response_id => response_3.id,
       :fr_question_id => fr1.id,


### PR DESCRIPTION
- Changes the labeling of the cost entry from $0.x to x¢ to make single-digit values more clear
- Fixes some typos reponse -> response
- Changes the units of duration, lifetime and auto-approve after from seconds to minutes
