### PR TITLE
Judges must have all qualifications in order to preview a HIT.

### DIFF
--- a/lib/m_turk_utils.rb
+++ b/lib/m_turk_utils.rb
@@ -163,7 +163,8 @@ module MTurkUtils
       if eval.mturk_qualification_type != nil
         props[:QualificationRequirement] = [{
           :QualificationTypeId => eval.mturk_qualification_type,
-          :Comparator => 'Exists'
+          :Comparator => 'Exists',
+          :RequiredToPreview => true          
         }]
       end
 

--- a/test/unit/models/evaluations_test.rb
+++ b/test/unit/models/evaluations_test.rb
@@ -294,7 +294,8 @@ class EvaluationsTest < ActiveSupport::TestCase
       :AutoApprovalDelayInSeconds => eval.auto_approve,
       :QualificationRequirement => [{
         :Comparator => 'Exists',
-        :QualificationTypeId => eval.mturk_qualification_type
+        :QualificationTypeId => eval.mturk_qualification_type,
+        :RequiredToPreview => true
       }]
     }).returns({
       :HITTypeId => 'ABCDEFG'


### PR DESCRIPTION
Currently, for example, non-masters can view a HIT even if the HIT is limited to masters (though they won't be able to work on it).

I added a parameter so that judges must have all qualifications in order to preview a HIT.
