### PR TITLE
Fix Thrift API for task submissions to sandboxed evaluations

### DIFF
--- a/lib/daemons/human_eval_thrift_daemon.rb
+++ b/lib/daemons/human_eval_thrift_daemon.rb
@@ -42,7 +42,7 @@ class HumanEvalTaskManagerHandler
     raise HumanEvalException.new("No Evaluation exists with the given name: #{task.humanEvalTaskType}") if evaluation.nil?
 
     new_task_to_submit = evaluation.add_task(field_values_map)
-    MTurkUtils.submit_task(new_task_to_submit)
+    MTurkUtils.submit_task(new_task_to_submit) if evaluation.prod? and submit_task_params.doSubmitToProduction
 
     response = HumanEvalSubmitTaskResponse.new
     response.taskId = new_task_to_submit.id


### PR DESCRIPTION
A task shouldn't be submitted to MTurk if its evaluation is sandboxed/non-prod.
