### PR TITLE
Update Thrift API: Changes the list of task IDs passed to fetchAnnotatio...

### DIFF
--- a/lib/daemons/human_eval_thrift_daemon.rb
+++ b/lib/daemons/human_eval_thrift_daemon.rb
@@ -19,13 +19,14 @@ Rails.application.require_environment!
 
 require 'thrift'
 require 'human_eval_task_manager'
+require 'set'
 
 class HumanEvalTaskManagerHandler
 
   # Initializes Thrift connection state.
   def initialize
     @processor = HumanEvalTaskManager::Processor.new(self)
-    @transport = Thrift::ServerSocket.new(9090)
+    @transport = Thrift::ServerSocket.new(3030)
     @transport_factory = Thrift::BufferedTransportFactory.new()
     @server = Thrift::SimpleServer.new(@processor, @transport, @transport_factory)
   end
@@ -52,9 +53,9 @@ class HumanEvalTaskManagerHandler
   # Gets the status of an existing Task, including completion status and answers, if available.
   # More details in human_eval.thrift.
   def fetchAnnotations(fetch_annotation_params)
-    return nil if fetch_annotation_params.nil? or fetch_annotation_params.taskIdList.nil?
+    return nil if fetch_annotation_params.nil? or fetch_annotation_params.taskIdSet.nil?
 
-    task_id_results_map = fetch_annotation_params.taskIdList.each_with_object({}) do |task_id, result|
+    task_id_results_map = fetch_annotation_params.taskIdSet.to_a.each_with_object({}) do |task_id, result|
       task_result = HumanEvalTaskResult.new
 
       task = Task.find_by_id(task_id)

--- a/lib/gen-rb/human_eval_types.rb
+++ b/lib/gen-rb/human_eval_types.rb
@@ -117,16 +117,16 @@ end
 
 class HumanEvalFetchAnnotationParams
   include ::Thrift::Struct, ::Thrift::Struct_Union
-  TASKIDLIST = 1
+  TASKIDSET = 1
 
   FIELDS = {
-    TASKIDLIST => {:type => ::Thrift::Types::LIST, :name => 'taskIdList', :element => {:type => ::Thrift::Types::I64}}
+    TASKIDSET => {:type => ::Thrift::Types::SET, :name => 'taskIdSet', :element => {:type => ::Thrift::Types::I64}}
   }
 
   def struct_fields; FIELDS; end
 
   def validate
-    raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field taskIdList is unset!') unless @taskIdList
+    raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field taskIdSet is unset!') unless @taskIdSet
   end
 
   ::Thrift::Struct.generate_accessors self

--- a/lib/human_eval.thrift
+++ b/lib/human_eval.thrift
@@ -55,7 +55,7 @@ service HumanEvalTaskManager {
    HumanEvalSubmitTaskResponse submitTask(1: HumanEvalSubmitTaskParams params)
        throws (1: HumanEvalException hec)
 
-   // Fetches result for a list of human eval tasks.
+   // Fetches result for a set of human eval tasks.
    HumanEvalFetchAnnotationResponse fetchAnnotations(1: HumanEvalFetchAnnotationParams params)
        throws (1: HumanEvalException hec)
 }

--- a/lib/human_eval.thrift
+++ b/lib/human_eval.thrift
@@ -42,7 +42,7 @@ struct HumanEvalSubmitTaskResponse {
 
 // Structure to represent params to fetch annotations.
 struct HumanEvalFetchAnnotationParams {
-  1: required list<i64> taskIdList;
+  1: required set<i64> taskIdSet;
 }
 
 // Structure to represent reponse from fetch annotations.


### PR DESCRIPTION
...ns to be a set

There is no reason for the collection of task IDs passed to fetchAnnotations to be ordered. So for generality I'm changing this to be a set instead of a list.
