### PR TITLE
Revert units of the auto-approve time to seconds.

### DIFF
--- a/app/views/evaluations/_form.html.haml
+++ b/app/views/evaluations/_form.html.haml
@@ -161,11 +161,11 @@
       %br
       %span.label-help
         Tasks will be automatically approved after this amount of time, in
-        minutes, unless you explicitly approve or reject the worker's
+        seconds, unless you explicitly approve or reject the worker's
         response
     .controls
       .input-append
-        = f.number_field :auto_approve_in_minutes
+        = f.number_field :auto_approve
         = render :partial => 'time_buttons'
 
   .form-actions


### PR DESCRIPTION
With the new Thrift API, we often want to run real-time tasks where we instantly approve judgments, so we need to be able to auto-approve at seconds granularity.
