### PR TITLE
Self-serve tasks

### DIFF
--- a/app/assets/stylesheets/tasks/complete.css.less
+++ b/app/assets/stylesheets/tasks/complete.css.less
@@ -1,0 +1,38 @@
+body.tasks.complete, body.tasks.submit {
+    .timeline {
+      height: 200px;
+      width: 500px;
+      overflow-y: scroll;
+      padding: 10px;
+      border: 1px solid black;
+    }
+
+    h1 {
+      margin-top: 20px;
+      margin-bottom: 5px;
+      width: 100%;
+      border-bottom: 1px solid black;
+    }
+
+    h3 {
+      margin-top: 10px;
+    }
+
+    form label {
+      font-weight: bold;
+      margin-top: 10px;
+    }
+
+    label.error {
+      display:none;
+    }
+
+    legend {
+      border-bottom: none;
+      margin-bottom: 5px;
+    }
+
+    .section {
+      margin-bottom: 20px;
+    }
+}

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -16,13 +16,74 @@ class TasksController < ApplicationController
   # GET /evaluations/1/tasks/1
   def show
     @task = Task.find(params[:id])
+    @mturk = true
+    render 'mturk', :layout => 'mturk'
+  end
 
-    render :layout => 'mturk'
+  # GET /evaluations/1/tasks/1/complete
+  def complete
+    @task = Task.find(params[:id])
+    @mturk = false
+    render 'internal'
+  end
+
+  # POST /evaluations/1/tasks/1/complete
+  def submit
+    evaluation = Evaluation.find params[:evaluation_id]
+    @task = Task.find params[:id]
+
+    @response = @task.build_task_response
+    @response.source = 'internal'
+    @response.m_turk_user = MTurkUser.find_or_create_by_id_and_prod(current_user.username, false)
+    @response.work_duration = Time.now.to_i - params[:start_time].to_i
+
+    params[:evaluation][:mc_q].each do |q_id, a_id|
+      begin
+        option = MCQuestionOption.find a_id.to_i
+      rescue ActiveRecord::RecordNotFound
+        Rails.logger.warn("[fetch_results] Could not find MCQuestion #{answer_content}")
+        next
+      end
+
+      question_response = @response.mc_question_responses.build
+      question_response.mc_question_option = option
+    end
+
+    params[:evaluation][:fr_q].each do |q_id, resp|
+      begin
+        question = FRQuestion.find q_id.to_i
+      rescue ActiveRecord::RecordNotFound
+        Rails.logger.warn("[fetch_results] Could not find FRQuestion #{question_id}")
+        next
+      end
+
+      question_response = @response.fr_question_responses.build
+
+      if resp.blank?
+        resp = "No response given"
+      end
+
+      question_response.response = resp
+      question_response.fr_question = question
+    end
+
+    if @response.save
+      MTurkUtils.force_expire @task
+      @task.add_metadata_as_questions
+      task = evaluation.random_uncompleted_task
+      if task
+        redirect_to complete_evaluation_task_url(evaluation, task)
+      else
+        redirect_to evaluation_url(evaluation)
+      end
+    else
+      render 'internal'
+    end
   end
 
   # Renders the given task (as in #show), returning a string of the rendering
   def show_string task
     @task = task
-    render_to_string :action => "show", :layout => 'mturk'
+    render_to_string :action => "mturk", :layout => 'mturk'
   end
 end

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -182,6 +182,16 @@ class Evaluation < ActiveRecord::Base
     self.tasks.find(:first, :offset => rand(self.tasks.size))
   end
 
+  def random_uncompleted_task
+    tasks = self.tasks.joins('LEFT OUTER JOIN clockwork_raven_task_responses ON clockwork_raven_task_responses.task_id = clockwork_raven_tasks.id').
+                       where('clockwork_raven_task_responses.id IS NULL')
+
+    # special-case this: rand(0) gives a floating point between 0 and 1
+    return nil if tasks.empty?
+
+    tasks.find(:first, :offset => rand(tasks.size))
+  end
+
   # Returns the name of the current status as a symbol: :new, :submitted,
   # :closed, :approved, or :purged.
   def status_name
@@ -351,13 +361,13 @@ class Evaluation < ActiveRecord::Base
     return 0 if median == 0
     (1.0/median) * (60.0*60.0) * self.payment
   end
-  
+
   # Array of the names of the columns in the original data file.
   # For example, ["tweet_id", "username", "score"]
   def original_data_column_names
-     if self.tasks.empty? 
+     if self.tasks.empty?
        []
-     else 
+     else
        self.tasks.first.data.keys
      end
   end

--- a/app/views/evaluations/show.html.haml
+++ b/app/views/evaluations/show.html.haml
@@ -92,6 +92,16 @@
 .eval-actions
   .clear
 
+  - if @evaluation.status_name == :submitted
+    %p
+      %b Number of tasks completed:
+      = @evaluation.available_results_count
+
+  - if [:closed, :approved, :purged].include?(@evaluation.status_name) or @evaluation.task_responses.size > 0
+    %p
+      %b Number of results in Clockwork Raven:
+      = @evaluation.task_responses.size
+
   - if @evaluation.job and !@evaluation.job.ended?
     %p
       This evaluation is being processed.
@@ -119,20 +129,18 @@
                 :confirm => confirm
 
     - if @evaluation.status_name == :submitted
-      %p
-        %b Number of tasks completed:
-        = @evaluation.available_results_count
 
       = link_to 'View on MTurk', @evaluation.mturk_url, :class => 'btn', :target => '_blank'
+
+      - rand_task = @evaluation.random_uncompleted_task
+      - if rand_task
+        = link_to "Complete Tasks", complete_evaluation_task_url(@evaluation, rand_task), :class => 'btn'
 
       = link_to 'Close Evaluation', close_evaluation_path(@evaluation),
                 :class => 'btn btn-primary', :method => 'post',
                 :confirm => "Are you sure? All tasks will be closed and no more MTurk users will be able to complete tasks."
 
-    - if [:closed, :approved, :purged].include? @evaluation.status_name
-      %p
-        %b Number of results:
-        = @evaluation.task_responses.size
+    - if [:closed, :approved, :purged].include?(@evaluation.status_name) or @evaluation.task_responses.size > 0
 
       = link_to 'View Responses', evaluation_task_responses_path(@evaluation), :class => 'btn'
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -20,6 +20,7 @@
     %script{:type => 'text/javascript', :src => '//platform.twitter.com/widgets.js', :charset => 'utf-8'}
     %script{:type => 'text/javascript', :src => '//www.google.com/jsapi'}
     = javascript_include_tag "application"
+    %script{:type => 'text/javascript', :src => '//ajax.aspnetcdn.com/ajax/jquery.validate/1.9/jquery.validate.min.js'}
     = csrf_meta_tags
     %link{:rel => 'icon', :type => 'image/png', :href => '/assets/raven.png'}
 

--- a/app/views/tasks/_fr_question.html.haml
+++ b/app/views/tasks/_fr_question.html.haml
@@ -1,0 +1,3 @@
+%legend{:for => name}= fr_q.label
+%label.error.alert.alert-error{:for => name} Please enter a response.
+%textarea{:cols => 40, :rows => 5, :name => name, :class => (fr_q.required? ? 'required' : '')}

--- a/app/views/tasks/_header.html.haml
+++ b/app/views/tasks/_header.html.haml
@@ -1,0 +1,1 @@
+%h1= interpolate(content, data)

--- a/app/views/tasks/_mc_question.html.haml
+++ b/app/views/tasks/_mc_question.html.haml
@@ -1,0 +1,7 @@
+%fieldset
+  %legend= mc_q.label
+  %label.error.alert.alert-error{:for => name} Please select a response.
+  - mc_q.mc_question_options.each do |option|
+    %label.option-label{:for => option.id}
+      %input{:type => 'radio', :name => name, :value => option.id, :class => 'required', :id => option.id}
+      %span.option-label-text= option.label

--- a/app/views/tasks/_text.html.haml
+++ b/app/views/tasks/_text.html.haml
@@ -1,0 +1,1 @@
+%div= interpolate(content, data)

--- a/app/views/tasks/internal.html.haml
+++ b/app/views/tasks/internal.html.haml
@@ -1,0 +1,50 @@
+-# Copyright 2012 Twitter, Inc. and others.
+-#
+-# Licensed under the Apache License, Version 2.0 (the "License");
+-# you may not use this file except in compliance with the License.
+-# You may obtain a copy of the License at
+-#
+-#     http://www.apache.org/licenses/LICENSE-2.0
+-#
+-# Unless required by applicable law or agreed to in writing, software
+-# distributed under the License is distributed on an "AS IS" BASIS,
+-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-# See the License for the specific language governing permissions and
+-# limitations under the License.
+
+-if @response and @response.errors.any?
+  #error_explanation.alert.alert-error
+    %a.close{'data-dismiss' => 'alert', 'href' => '#'} ×
+    %h4.alert-heading= "#{pluralize(@response.errors.count, "error")} prohibited this response from being saved:"
+    %ul
+      - @response.errors.full_messages.each do |msg|
+        %li= msg
+
+= form_for submit_evaluation_task_path(params[:evaluation_id], params[:id]) do
+  %input{:type => 'hidden', :name => 'start_time', :value => Time.now.to_i}
+  - @task.evaluation.template.each do |section|
+    .section
+      - case section[:type]
+      - when :_mc
+        - mc_q = @task.evaluation.mc_questions.find_by_order(section[:order])
+        - name = "evaluation[mc_q][#{mc_q.id}]"
+        = render :partial => 'mc_question', :locals => {:mc_q => mc_q, :name => name}
+      - when :_fr
+        - fr_q = @task.evaluation.fr_questions.find_by_order(section[:order])
+        - name = "evaluation[fr_q][#{fr_q.id}]"
+        = render :partial => 'fr_question', :locals => {:fr_q => fr_q, :name => name}
+      - when :_text
+        = render :partial => 'text', :locals => {:content => section[:content], :data => @task.data}
+      - when :_header
+        = render :partial => 'header', :locals => {:content => section[:content], :data => @task.data}
+      - else
+        = render :partial => "components/#{section[:type]}", :locals => {:data => resolve_data(section[:data], @task.data)}
+
+
+  %input.btn.btn-primary{:type => 'submit', :value => 'Submit', :id => 'submitButton'}
+
+  -# Set up MTurk hidden field and javascript validation
+  %script{:language => 'Javascript'}
+    :plain
+      $('form').validate();
+

--- a/app/views/tasks/mturk.html.haml
+++ b/app/views/tasks/mturk.html.haml
@@ -12,7 +12,7 @@
 -# See the License for the specific language governing permissions and
 -# limitations under the License.
 
-%form{:name => 'mturk_form', :id => 'mturk_form', :method => 'post', :action => 'https://www.mturk.com/mturk/externalSubmit'}
+%form{:method => 'post', :action => (@task.evaluation.prod? ? 'https://www.mturk.com/mturk/externalSubmit' : 'http://workersandbox.mturk.com/mturk/externalSubmit')}
   -# This hidden field is for MTurk -- it gets populated by the
   -# turkSetAssignmentID() javascript call below
   %input{:type => 'hidden', :value => '', :name => 'assignmentId', :id => 'assignmentId'}
@@ -21,27 +21,17 @@
     .section
       - case section[:type]
       - when :_mc
-        -# Render radio buttons for MC questions
         - mc_q = @task.evaluation.mc_questions.find_by_order(section[:order])
-        - id = 'mc:' + mc_q.id.to_s
-        %fieldset
-          %legend= mc_q.label
-          %label.error.alert.alert-error{:for => id} Please select a response.
-          - mc_q.mc_question_options.each do |option|
-            %label.option-label{:for => option.id}
-              %input{:type => 'radio', :name => id, :value => option.id, :class => 'required', :id => option.id}
-              %span.option-label-text= option.label
+        - name = 'mc:' + mc_q.id.to_s
+        = render :partial => 'mc_question', :locals => {:mc_q => mc_q, :name => name}
       - when :_fr
-        -# Render textareas for FR Questions
         - fr_q = @task.evaluation.fr_questions.find_by_order(section[:order])
-        - id = 'fr:' + fr_q.id.to_s
-        %legend{:for => id}= fr_q.label
-        %label.error.alert.alert-error{:for => id} Please enter a response.
-        %textarea{:cols => 40, :rows => 5, :name => id, :class => (fr_q.required? ? 'required' : '')}
+        - name = 'fr:' + fr_q.id.to_s
+        = render :partial => 'fr_question', :locals => {:fr_q => fr_q, :name => name}
       - when :_text
-        %div= interpolate(section[:content], @task.data)
+        = render :partial => 'text', :locals => {:content => section[:content], :data => @task.data}
       - when :_header
-        %h1= interpolate(section[:content], @task.data)
+        = render :partial => 'header', :locals => {:content => section[:content], :data => @task.data}
       - else
         = render :partial => "components/#{section[:type]}", :locals => {:data => resolve_data(section[:data], @task.data)}
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,12 @@
 
 ClockworkRaven::Application.routes.draw do
   resources :evaluations do
-    resources :tasks
+    resources :tasks do
+      member do
+        get 'complete'
+        post 'complete' => 'tasks#submit', :as => 'submit'
+      end
+    end
 
     member do
       get 'original_data'

--- a/db/migrate/20121010052749_add_source_to_task_responses.rb
+++ b/db/migrate/20121010052749_add_source_to_task_responses.rb
@@ -1,0 +1,6 @@
+class AddSourceToTaskResponses < ActiveRecord::Migration
+  def change
+    add_column :task_responses, :source, :string
+
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -133,6 +133,7 @@ CREATE TABLE `clockwork_raven_task_responses` (
   `updated_at` timestamp NULL DEFAULT NULL,
   `mturk_assignment` varchar(255) DEFAULT NULL,
   `approved` tinyint(1) DEFAULT NULL,
+  `source` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `task_id` (`task_id`),
   CONSTRAINT `clockwork_raven_task_responses_ibfk_1` FOREIGN KEY (`task_id`) REFERENCES `clockwork_raven_tasks` (`id`)
@@ -176,3 +177,5 @@ INSERT INTO clockwork_raven_schema_migrations (version) VALUES ('20120807222553'
 INSERT INTO clockwork_raven_schema_migrations (version) VALUES ('20120810203402');
 
 INSERT INTO clockwork_raven_schema_migrations (version) VALUES ('20120911001453');
+
+INSERT INTO clockwork_raven_schema_migrations (version) VALUES ('20121010052749');

--- a/lib/m_turk_utils.rb
+++ b/lib/m_turk_utils.rb
@@ -164,7 +164,7 @@ module MTurkUtils
         props[:QualificationRequirement] = [{
           :QualificationTypeId => eval.mturk_qualification_type,
           :Comparator => 'Exists',
-          :RequiredToPreview => true          
+          :RequiredToPreview => true
         }]
       end
 
@@ -204,6 +204,7 @@ module MTurkUtils
       time = assignments[:Assignment][:SubmitTime] - assignments[:Assignment][:AcceptTime]
 
       response = task.build_task_response
+      response.source = 'mturk'
       response.m_turk_user = MTurkUser.find_or_create_by_id_and_prod worker_id, task.evaluation.prod
       response.work_duration = time
 
@@ -231,7 +232,6 @@ module MTurkUtils
             Rails.logger.warn("[fetch_results] Could not find FRQuestion #{question_id}")
             next
           end
-
           question_response = response.fr_question_responses.build
 
           if answer_content.blank?
@@ -288,7 +288,7 @@ module MTurkUtils
           next if mc_question_option.nil? or mc_question_option.mc_question.nil?
           answer_key, answer_value = mc_question_option.mc_question.label, mc_question_option.label
         end
-       
+
         next if answer_key.nil?
         answer_value = "No response given" if answer_value.nil?
         curr_answers_hash[answer_key] = answer_value

--- a/test/functional/controllers/tasks_controller_test.rb
+++ b/test/functional/controllers/tasks_controller_test.rb
@@ -25,6 +25,8 @@ class TasksControllerTest < ActionController::TestCase
     get :show, :id => task.id, :evaluation_id => task.evaluation.id
 
     assert_equal task, assigns(:task)
+    assert_equal true, assigns(:mturk)
+    assert_template :mturk
   end
 
   test "show_string" do
@@ -35,5 +37,121 @@ class TasksControllerTest < ActionController::TestCase
     get :show, :id => task.id, :evaluation_id => task.evaluation.id
 
     assert_equal response.body, @controller.show_string(task)
+  end
+
+  test "complete" do
+    task = create :task
+
+    get :complete, :id => task.id, :evaluation_id => task.evaluation.id
+
+    assert_equal task, assigns(:task)
+    assert_equal false, assigns(:mturk)
+    assert_template :internal
+  end
+
+  test "submit" do
+    # create an eval with some questions and 3 tasks
+    eval = create :evaluation_with_questions
+
+    mc1 = eval.mc_questions.first
+    mc1_1 = mc1.mc_question_options.first
+    mc1_2 = mc1.mc_question_options.second
+
+    mc2 = eval.mc_questions.second
+    mc2_1 = mc2.mc_question_options.first
+    mc2_2 = mc2.mc_question_options.second
+
+    fr1 = eval.fr_questions.first
+    fr2 = eval.fr_questions.second
+
+    task = create :task, :evaluation => eval, :mturk_hit => 'HIT_1'
+    task.data['metadata1'] = 'resp1a'
+    task.data['metadata2'] = 'resp2a'
+    task.save!
+
+    # close! should get rid of existing task responses, so we make on here
+    # to make sure it gets deleted
+    create :task_response, :task => task
+
+    # we expect a call to close this task
+    sb = mturk_sandbox_mock
+
+    sb.stubs(:forceExpireHIT).once.with({:HITId => task.mturk_hit})
+
+    params = {
+      :id => task.id,
+      :evaluation_id => eval.id,
+      :start_time => 60.seconds.ago.to_i.to_s,
+      :evaluation => {
+        :mc_q => {
+          mc1.id => mc1_1.id,
+          mc2.id => mc2_2.id
+        },
+        :fr_q => {
+          fr1.id => 'Answer_1',
+          fr2.id => 'Answer_2'
+        }
+      }
+    }
+
+    post :submit, params
+
+    # check that the task response is correct
+    eval.reload
+    assert_equal 1, eval.task_responses.size
+
+    # task 1
+    response = task.reload.task_response
+
+    # correct number of responses?
+    assert_equal 4, response.mc_question_responses.size
+    assert_equal 2, response.fr_question_responses.size
+
+    # work duration and worker set correctly?
+    assert_in_delta 60, response.work_duration, 1
+    assert_equal @user.username, response.m_turk_user.id
+
+    # multiple-choice questions - assert there is a response that belongs to
+    # this TaskResponse and the correct option. Check both actual questions
+    # and metadata
+    assert_not_nil MCQuestionResponse.where(
+      :task_response_id => response.id,
+      :mc_question_option_id => mc1_1.id
+    ).first
+
+    assert_not_nil MCQuestionResponse.where(
+      :task_response_id => response.id,
+      :mc_question_option_id => mc2_2.id
+    ).first
+
+    # metadata
+    assert_not_nil MCQuestionResponse.where(
+      :task_response_id => response.id,
+      :mc_question_option_id => MCQuestion.find_by_label('metadata1').
+                                           mc_question_options.
+                                           where(:label => 'resp1a').
+                                           first.id
+    ).first
+
+    assert_not_nil MCQuestionResponse.where(
+      :task_response_id => response.id,
+      :mc_question_option_id => MCQuestion.find_by_label('metadata2').
+                                           mc_question_options.
+                                           where(:label => 'resp2a').
+                                           first.id
+    ).first
+
+    # free-response questions
+    assert_not_nil FRQuestionResponse.where(
+      :task_response_id => response.id,
+      :fr_question_id => fr1.id,
+      :response => "Answer_1"
+    ).first
+
+    assert_not_nil FRQuestionResponse.where(
+      :task_response_id => response.id,
+      :fr_question_id => fr2.id,
+      :response => "Answer_2"
+    ).first
   end
 end

--- a/test/unit/models/evaluations_test.rb
+++ b/test/unit/models/evaluations_test.rb
@@ -144,17 +144,17 @@ class EvaluationsTest < ActiveSupport::TestCase
     assert_equal 1, eval.tasks.size
     assert_equal expected_task_data, eval.tasks.first.data
   end
-  
+
   test "original data column names" do
     eval = create :evaluation
 
     assert_equal 0, eval.original_data_column_names.size, "Column names for eval without data incorrect"
-    
+
     eval.add_tasks(parse_json_fixture('data1.json'))
     expected_column_names = %w(foo1 foo2)
-    
+
     assert_equal expected_column_names, eval.original_data_column_names, "Column names for eval incorrect"
-  end  
+  end
 
   test "random task" do
     eval = create :evaluation_with_tasks, :task_count => 2
@@ -449,5 +449,27 @@ class EvaluationsTest < ActiveSupport::TestCase
     assert_equal 0, eval4.median_time
     assert_equal 0, eval4.mean_pay_rate
     assert_equal 0, eval4.median_pay_rate
+  end
+
+  test "random uncompleted task" do
+    e = create :evaluation
+    t1 = create :task, :evaluation => e
+    create :task_response, :task => t1
+    t2 = create :task, :evaluation => e
+    assert_equal t2, e.random_uncompleted_task
+  end
+
+  test "random uncompleted task, no tasks" do
+    e = create :evaluation
+    assert_nil e.random_uncompleted_task
+  end
+
+  test "random uncompleted task, no such task" do
+    e = create :evaluation
+    t1 = create :task, :evaluation => e
+    create :task_response, :task => t1
+    t2 = create :task, :evaluation => e
+    create :task_response, :task => t2
+    assert_nil e.random_uncompleted_task
   end
 end


### PR DESCRIPTION
This change allows CR users to complete tasks themselves using a self-serve interface that makes the results immediately available via the "view results" page.
