### PR TITLE
Simplify evaluation page.

### DIFF
--- a/app/controllers/evaluations_controller.rb
+++ b/app/controllers/evaluations_controller.rb
@@ -230,8 +230,9 @@ class EvaluationsController < ApplicationController
 
   # GET /evaluations/1/random_task
   def random_task
-    task = @evaluation.random_task
-    redirect_to evaluation_task_url(@evaluation, task)
+    @task = @evaluation.random_task
+
+    render 'tasks/show', :layout => 'mturk'
   end
 
   # POST /evaluations/1/submit

--- a/app/controllers/evaluations_controller.rb
+++ b/app/controllers/evaluations_controller.rb
@@ -174,11 +174,10 @@ class EvaluationsController < ApplicationController
     if success
       success = false
       @evaluation.transaction do
-        if params[:evaluation][:replace_data] == '1'
-          @evaluation.tasks.destroy_all
-        end
-
         if data
+          # We are uploading a new dataset, so remove any existing tasks
+          # before adding tasks from the new file.
+          @evaluation.tasks.destroy_all
           @evaluation.add_tasks data
         end
 

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -218,7 +218,7 @@ class Evaluation < ActiveRecord::Base
   # fields to copy when basing an evaluation on another evaluation
   BASED_ON_FIELDS = [:desc, :keywords, :payment, :duration,
                      :lifetime, :auto_approve, :mturk_qualification, :title,
-                     :template, :metadata]
+                     :template, :metadata, :note, :prod]
 
   # Copies specific parts of this evaluation. instructions, desc, keywords,
   # payment, duration, lifetime, auto_approve, mturk_qualification, template,
@@ -232,6 +232,7 @@ class Evaluation < ActiveRecord::Base
     e = Evaluation.new
 
     # copy fields
+    e.name = "Copy of #{base.name}"
     BASED_ON_FIELDS.each do |field|
       e[field] = base[field]
     end
@@ -351,13 +352,13 @@ class Evaluation < ActiveRecord::Base
     return 0 if median == 0
     (1.0/median) * (60.0*60.0) * self.payment
   end
-  
+
   # Array of the names of the columns in the original data file.
   # For example, ["tweet_id", "username", "score"]
   def original_data_column_names
-     if self.tasks.empty? 
+     if self.tasks.empty?
        []
-     else 
+     else
        self.tasks.first.data.keys
      end
   end

--- a/app/views/evaluations/_form.html.haml
+++ b/app/views/evaluations/_form.html.haml
@@ -40,16 +40,6 @@
       = f.text_field :name
 
   .control-group
-    %label.control-label{:for => 'evaluation_prod'}
-      Production?
-      %br
-      %span.label-help
-        If checked, the job will be sent to the real MTurk. Else, it will be
-        sent to the sandbox.
-    .controls
-      = f.check_box :prod
-
-  .control-group
     %label.control-label{:for => 'evaluation_title'}
       %span.form-required
         Title
@@ -57,6 +47,15 @@
       %span.label-help Shown to MTurk Users
     .controls
       = f.text_field :title
+
+  .control-group
+    %label.control-label{:for => 'evaluation_desc'}
+      %span.form-required
+        Description
+      %br
+      %span.label-help Shown to MTurk users searching for a task
+    .controls
+      = f.text_area :desc, :rows => 5
 
   .control-group
     %label.control-label{:for => 'evaluation_note'}
@@ -67,10 +66,21 @@
       = f.text_area :note, :rows => 5
 
   .control-group
+    %label.control-label{:for => 'evaluation_payment'}
+      %span.form-required
+        Payment
+      %br
+      %span.label-help Amount paid to MTurk workers for each task, in cents
+    .controls
+      .input-prepend
+        = f.number_field :payment
+        %span.add-on &cent;
+
+  .control-group
     %label.control-label{:for => 'evaluation_data'}
       Data
       %br
-      %span.label-help CSV, TSV, or JSON. Must be UTF-8 encoded.
+      %span.label-help CSV, TSV, or JSON. Must be UTF-8 encoded and have the appropriate file extension
     .controls
       = f.file_field :data
 
@@ -83,90 +93,85 @@
       .controls
         = f.check_box :replace_data
 
-  .control-group
-    %label.control-label{:for => 'evaluation_desc'}
-      %span.form-required
-        Description
-      %br
-      %span.label-help Shown to MTurk users searching for a task
-    .controls
-      = f.text_area :desc, :rows => 5
+  .accordion-heading
+    %a.accordion-toggle{'data-toggle' => 'collapse', :href => '#advancedSettingsPane'} Advanced settings...
+  #advancedSettingsPane.accordion-body.collapse
+    .accordion-inner
 
-  .control-group
-    %label.control-label{:for => 'evaluation_keywords'}
-      Keywords
-      %br
-      %span.label-help Comma-separated keywords to help MTurk users find the task
-    .controls
-      = f.text_field :keywords
+      .control-group
+        %label.control-label{:for => 'evaluation_prod'}
+          Production?
+          %br
+          %span.label-help
+            If checked, the job will be sent to the real MTurk. Else, it will be
+            sent to the sandbox.
+        .controls
+          = f.check_box :prod
 
-  .control-group
-    %label.control-label{:for => 'evaluation_mturk_qualification'}
-      Qualification
-      %br
-      %span.label-help
-        "Masters" restricts this evaluation to users MTurk considers categorization masters.
-        "Trusted" restricts this evaluation to users marked as trusted in Clockwork Raven.
-    .controls
-      = f.radio_button :mturk_qualification, 'none'
-      None
-      %br
-      = f.radio_button :mturk_qualification, 'master'
-      Masters
-      %br
-      = f.radio_button :mturk_qualification, 'trusted'
-      Trusted
+      .control-group
+        %label.control-label{:for => 'evaluation_mturk_qualification'}
+          Qualification
+          %br
+          %span.label-help
+            "Masters" restricts this evaluation to users MTurk considers categorization masters.
+            "Trusted" restricts this evaluation to users marked as trusted in Clockwork Raven.
+        .controls
+          = f.radio_button :mturk_qualification, 'none'
+          None
+          %br
+          = f.radio_button :mturk_qualification, 'master'
+          Masters
+          %br
+          = f.radio_button :mturk_qualification, 'trusted'
+          Trusted
 
-  .control-group
-    %label.control-label{:for => 'evaluation_payment'}
-      %span.form-required
-        Payment
-      %br
-      %span.label-help Amount payed to MTurk workers for each task, in cents
-    .controls
-      .input-prepend
-        = f.number_field :payment
-        %span.add-on &cent;
+      .control-group
+        %label.control-label{:for => 'evaluation_keywords'}
+          Keywords
+          %br
+          %span.label-help Comma-separated keywords to help MTurk users find the task
+        .controls
+          = f.text_field :keywords
 
-  .control-group
-    %label.control-label{:for => 'evaluation_duration'}
-      %span.form-required
-        Duration
-      %br
-      %span.label-help
-        Amount of time, in minutes, a worker has to complete this task before
-        it can be given to someone else
-    .controls
-      .input-append
-        = f.number_field :duration_in_minutes
-        = render :partial => 'time_buttons'
+      .control-group
+        %label.control-label{:for => 'evaluation_duration'}
+          %span.form-required
+            Duration
+          %br
+          %span.label-help
+            Amount of time, in minutes, a worker has to complete this task before
+            it can be given to someone else
+        .controls
+          .input-append
+            = f.number_field :duration_in_minutes
+            = render :partial => 'time_buttons'
 
-  .control-group
-    %label.control-label{:for => 'evaluation_lifetime'}
-      %span.form-required
-        Lifetime
-      %br
-      %span.label-help
-        Amount of time, in minutes, this evaluation will be available on MTurk
-        after it is submitted
-    .controls
-      .input-append
-        = f.number_field :lifetime_in_minutes
-        = render :partial => 'time_buttons'
+      .control-group
+        %label.control-label{:for => 'evaluation_lifetime'}
+          %span.form-required
+            Lifetime
+          %br
+          %span.label-help
+            Amount of time, in minutes, this evaluation will be available on MTurk
+            after it is submitted
+        .controls
+          .input-append
+            = f.number_field :lifetime_in_minutes
+            = render :partial => 'time_buttons'
 
-  .control-group
-    %label.control-label{:for => 'evaluation_auto_approve'}
-      %span.form-required
-        Auto-approve After
-      %br
-      %span.label-help
-        Tasks will be automatically approved after this amount of time, in
-        minutes, unless you explicitly approve or reject the worker's
-        response
-    .controls
-      .input-append
-        = f.number_field :auto_approve_in_minutes
-        = render :partial => 'time_buttons'
+      .control-group
+        %label.control-label{:for => 'evaluation_auto_approve'}
+          %span.form-required
+            Auto-approve After
+          %br
+          %span.label-help
+            Tasks will be automatically approved after this amount of time, in
+            minutes, unless you explicitly approve or reject the worker's
+            response
+        .controls
+          .input-append
+            = f.number_field :auto_approve_in_minutes
+            = render :partial => 'time_buttons'
 
   .form-actions
     = f.submit 'Save', :class => 'btn btn-primary'

--- a/app/views/evaluations/show.html.haml
+++ b/app/views/evaluations/show.html.haml
@@ -51,8 +51,9 @@
   %b Number of tasks:
   = @evaluation.tasks.size
 
-%p
-  %a{:href => random_task_evaluation_url(@evaluation)} Preview random task
+- unless @evaluation.tasks.empty?
+  %p
+    %a{:href => random_task_evaluation_url(@evaluation)} Preview random task
 
 %p
   %b Qualifications:
@@ -66,7 +67,7 @@
 %h2 Questions
 
 - if @evaluation.mc_questions.empty? && @evaluation.fr_questions.empty?
-  %p This evaluation has no multiple-choice or free response questions.
+  %p This evaluation has no questions.
 
 - unless @evaluation.mc_questions.empty?
   %h3 Multiple-Choice

--- a/app/views/evaluations/show.html.haml
+++ b/app/views/evaluations/show.html.haml
@@ -65,29 +65,34 @@
 
 %h2 Questions
 
-%h3 Multiple-Choice
+- if @evaluation.mc_questions.empty? && @evaluation.fr_questions.empty?
+  %p This evaluation has no multiple-choice or free response questions.
 
-%ol
-  - @evaluation.mc_questions.reject{|q| q.metadata}.each do |q|
-    %li
-      = q.label
-      %ul
-        - q.mc_question_options.each do |o|
-          %li
-            = o.label
-            - if o.value?
-              (value: #{o.value})
+- unless @evaluation.mc_questions.empty?
+  %h3 Multiple-Choice
 
-%h3 Free-Response
+  %ol
+    - @evaluation.mc_questions.reject{|q| q.metadata}.each do |q|
+      %li
+        = q.label
+        %ul
+          - q.mc_question_options.each do |o|
+            %li
+              = o.label
+              - if o.value?
+                (value: #{o.value})
 
-%ol
-  - @evaluation.fr_questions.each do |q|
-    %li= q.label
+- unless @evaluation.fr_questions.empty?
+  %h3 Free-Response
+
+  %ol
+    - @evaluation.fr_questions.each do |q|
+      %li= q.label
 
 .eval-actions
   .clear
 
-  - if @evaluation.job and !@evaluation.job.ended?
+  - if @evaluation.job && !@evaluation.job.ended?
     %p
       This evaluation is being processed.
       = link_to "View Job &raquo;".html_safe, @evaluation.job
@@ -114,7 +119,7 @@
       = link_to 'Close Evaluation', close_evaluation_path(@evaluation),
                 :class => 'btn btn-primary', :method => 'post',
                 :confirm => "Are you sure? All tasks will be closed and no more MTurk users will be able to complete tasks."
-    
+
     - if [:closed, :approved, :purged].include? @evaluation.status_name
       %p
         %b Number of results:
@@ -132,7 +137,7 @@
             = link_to 'CSV', evaluation_task_responses_path(@evaluation, :format => 'csv')
             = link_to 'JSON', evaluation_task_responses_path(@evaluation, :format => 'json')
 
-    - unless @evaluation.tasks.empty?     
+    - unless @evaluation.tasks.empty?
       .btn-group
         %a.btn.dropdown-toggle{:href => '#', 'data-toggle' => 'dropdown'}
           Download Original Data

--- a/db/migrate/20121020214517_change_evaluations_prod_field_to_default_true.rb
+++ b/db/migrate/20121020214517_change_evaluations_prod_field_to_default_true.rb
@@ -1,0 +1,5 @@
+class ChangeEvaluationsProdFieldToDefaultTrue < ActiveRecord::Migration
+  def change
+    change_column :evaluations, :prod, :integer, :default => true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -14,7 +14,7 @@ CREATE TABLE `clockwork_raven_evaluations` (
   `mturk_qualification` varchar(255) NOT NULL DEFAULT 'trusted',
   `title` varchar(255) NOT NULL DEFAULT '',
   `note` varchar(255) DEFAULT NULL,
-  `prod` int(11) NOT NULL DEFAULT '0',
+  `prod` int(11) NOT NULL DEFAULT '1',
   `template` text,
   `metadata` text,
   `user_id` int(11) NOT NULL,
@@ -50,6 +50,15 @@ CREATE TABLE `clockwork_raven_fr_questions` (
   KEY `evaluation_id` (`evaluation_id`),
   CONSTRAINT `clockwork_raven_fr_questions_ibfk_1` FOREIGN KEY (`evaluation_id`) REFERENCES `clockwork_raven_evaluations` (`id`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
+
+CREATE TABLE `clockwork_raven_job_parts` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `job_id` int(11) DEFAULT NULL,
+  `data` text COLLATE utf8_unicode_ci,
+  `status` int(11) DEFAULT '0',
+  `error` text COLLATE utf8_unicode_ci,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 CREATE TABLE `clockwork_raven_jobs` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -165,3 +174,5 @@ INSERT INTO clockwork_raven_schema_migrations (version) VALUES ('20120806234641'
 INSERT INTO clockwork_raven_schema_migrations (version) VALUES ('20120807222553');
 
 INSERT INTO clockwork_raven_schema_migrations (version) VALUES ('20120810203402');
+
+INSERT INTO clockwork_raven_schema_migrations (version) VALUES ('20121020214517');

--- a/test/functional/controllers/evaluations_controller_test.rb
+++ b/test/functional/controllers/evaluations_controller_test.rb
@@ -276,15 +276,15 @@ class EvaluationsControllerTest < ActionController::TestCase
   end
 
   test "random task" do
-    # we already test Evaluation#random_task, so just check that is uses that
-    # and that it redirects to something valid
+    # we already test Evaluation#random_task, so just check that this uses that
+    # and that it renders the task
 
     e = create :evaluation_with_tasks
     e.expects(:random_task).returns(e.tasks.first)
     Evaluation.stubs(:find).with(e.id.to_s).returns(e)
 
     get :random_task, :id => e.id
-    assert_redirected_to evaluation_task_path(e, e.tasks.first)
+    assert_template 'tasks/show'
   end
 
   # This asserts that a method that normally spawns off a job to interact

--- a/test/functional/controllers/evaluations_controller_test.rb
+++ b/test/functional/controllers/evaluations_controller_test.rb
@@ -217,21 +217,19 @@ class EvaluationsControllerTest < ActionController::TestCase
     end
   end
 
-  test "update add tasks" do
+  test "update replace tasks" do
     # create an eval with the data from task1.json
     e = create :evaluation
     e.add_tasks parse_json_fixture('data1.json')
 
-    # add the data from task2.json
+    # replace with data from task2.json
     post :update, :id => e.id, :evaluation => {:data => fixture_file_upload('data2.json')}
     assert_redirected_to evaluation_path(e.id)
 
-    # assert data added correctly
-    assert_equal 4, e.tasks.size
-    assert_equal e.tasks.first.data, {'foo1' => 'bar1', 'foo2' => 'bar2'}
-    assert_equal e.tasks.second.data, {'foo1' => 'bar3', 'foo2' => 'bar4'}
-    assert_equal e.tasks.third.data, {'foo1' => 'bar5', 'foo2' => 'bar6'}
-    assert_equal e.tasks.fourth.data, {'foo1' => 'bar7', 'foo2' => 'bar8'}
+    # assert data fram task2.json replaced data from task1.json
+    assert_equal 2, e.tasks.size
+    assert_equal e.tasks.first.data, {'foo1' => 'bar5', 'foo2' => 'bar6'}
+    assert_equal e.tasks.second.data, {'foo1' => 'bar7', 'foo2' => 'bar8'}
   end
 
   test "destroy" do

--- a/test/unit/models/evaluations_test.rb
+++ b/test/unit/models/evaluations_test.rb
@@ -144,17 +144,17 @@ class EvaluationsTest < ActiveSupport::TestCase
     assert_equal 1, eval.tasks.size
     assert_equal expected_task_data, eval.tasks.first.data
   end
-  
+
   test "original data column names" do
     eval = create :evaluation
 
     assert_equal 0, eval.original_data_column_names.size, "Column names for eval without data incorrect"
-    
+
     eval.add_tasks(parse_json_fixture('data1.json'))
     expected_column_names = %w(foo1 foo2)
-    
+
     assert_equal expected_column_names, eval.original_data_column_names, "Column names for eval incorrect"
-  end  
+  end
 
   test "random task" do
     eval = create :evaluation_with_tasks, :task_count => 2
@@ -236,14 +236,9 @@ class EvaluationsTest < ActiveSupport::TestCase
     copy = Evaluation.based_on eval
     # make sure properties that should be copied are copied
     [:desc, :keywords, :payment, :duration, :lifetime, :auto_approve,
-     :mturk_qualification, :title, :metadata, :template].each do |field|
+     :mturk_qualification, :title, :metadata, :template, :note, :prod].each do |field|
 
       assert_equal eval[field], copy[field], "Field #{field} was not copied"
-    end
-
-    # make sure properties that shouldn't be copies aren't copied
-    [:name, :note, :prod].each do |field|
-      assert_not_equal eval[field], copy[field], "Field #{field} was copied"
     end
 
     # fill in name and user id so we can save and use associations


### PR DESCRIPTION
The current evaluation page is a little complicated, so I simplified it a bit.
- Default all evaluations to prod=true (adds a migration so that the prod field is true by default in the db).
- Hide some of the more advanced, rarely changed fields in the evaluation form under an accordion.
- Reorder some of the other evaluation form fields.
- Don't show MC or FR questions in the preview on the show evaluation page, if there are none. (fixes issue #35)
- Always replace data when uploading a new file to the evaluation.
- Hide the "preview random task" link if there are no tasks. 
- When previewing a random task, render the task template instead of redirecting to it, so that it's easier to preview several different random tasks (by refreshing, instead of going back to the evaluation page and clicking the preview link again).

Here's what the new show page looks like:

[![Show Evaluation Page](https://dl.dropbox.com/u/10506/mechanical_turk/show-evaluation-page.png)](https://dl.dropbox.com/u/10506/mechanical_turk/show-evaluation-page.png)
