### PR TITLE
Use \x00 as the default quote char when parsing CSVs/TSVs.

### DIFF
--- a/lib/input_parser.rb
+++ b/lib/input_parser.rb
@@ -64,7 +64,8 @@ module InputParser
       CSV.parse(content, :col_sep => sep,
                          :converters => [:numeric],
                          :headers => true,
-                         :skip_blanks => true).
+                         :skip_blanks => true,
+                         :quote_char => "\x00").
           map{ |row| row.to_hash }
     end
 


### PR DESCRIPTION
By default, the quote char that the CSV parser uses (to quote fields) is "
http://ruby-doc.org/stdlib-1.9.2/libdoc/csv/rdoc/CSV.html#method-c-new

This causes a lot of parsing errors, though, since people often upload files with legitimate quotation marks. (It's quite rare, at least in my experience, to actually have quoted fields in a CSV/TSV.)

AFAICT, there's no way to tell the parser that columns are never quoted, so per the SO suggestion [here](http://stackoverflow.com/questions/8073920/importing-csv-ruby-1-9-2-quoting-error-driving-me-nuts), I'm using a zero-byte char (which should never occur) as my quote char.
