### PR TITLE
Remove the 'replace data fields' in the evaluation form.

### DIFF
--- a/app/views/evaluations/_form.html.haml
+++ b/app/views/evaluations/_form.html.haml
@@ -84,15 +84,6 @@
     .controls
       = f.file_field :data
 
-  - unless @evaluation.new_record?
-    .control-group
-      %label.control-label{:for => 'evaluation_replace_data'}
-        Replace data?
-        %br
-        %span.label-help If checked, existing data will be deleted
-      .controls
-        = f.check_box :replace_data
-
   .accordion-heading
     %a.accordion-toggle{'data-toggle' => 'collapse', :href => '#advancedSettingsPane'} Advanced settings...
   #advancedSettingsPane.accordion-body.collapse


### PR DESCRIPTION
In [this CL](https://github.com/twitter/clockworkraven/pull/43), I made a change so that data is always replaced when uploading a new file to an evaluation, but I forgot to remove the "replace data" checkboxes in the evaluation form. This removes that checkbox.
