### PR TITLE
Fix bad data tests.

### DIFF
--- a/test/fixtures/bad1.tsv
+++ b/test/fixtures/bad1.tsv
@@ -1,3 +1,0 @@
-foo1	foo2
-bar9	bar10
-bar11	bar12"

--- a/test/functional/controllers/evaluations_controller_test.rb
+++ b/test/functional/controllers/evaluations_controller_test.rb
@@ -182,7 +182,7 @@ class EvaluationsControllerTest < ActionController::TestCase
 
   end
 
-  BAD_FILES = ['bad1.tsv', 'bad2.json', 'bad3.json', 'bad4.json', 'bad5.json', 'bad6.json']
+  BAD_FILES = ['bad2.json', 'bad3.json', 'bad4.json', 'bad5.json', 'bad6.json']
 
   test "update with bad data" do
     BAD_FILES.each do |file|


### PR DESCRIPTION
With [CL #47](https://github.com/twitter/clockworkraven/pull/47), the `bad1.tsv` fixture (which included a quotation mark in one of the fields) is no longer a bad tsv file, so I removed it from the "bad data" tests.
