### PR TITLE
Make code 1.8.7-compatible.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'rails', '3.2.1'
 
 #  gem 'sqlite3'
 
+gem 'fastercsv'
 gem 'json'
 
 # Gems used only for assets and not required

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.8.4)
       multipart-post (~> 1.1)
+    fastercsv (1.5.5)
     haml (3.1.7)
     haml-rails (0.3.5)
       actionpack (>= 3.1, < 4.1)
@@ -188,6 +189,7 @@ DEPENDENCIES
   bootstrap-will_paginate
   coffee-rails (~> 3.2.1)
   factory_girl_rails (< 3.0.0)
+  fastercsv
   haml-rails
   highline
   jquery-rails

--- a/app/controllers/evaluations_controller.rb
+++ b/app/controllers/evaluations_controller.rb
@@ -63,22 +63,10 @@ class EvaluationsController < ApplicationController
 
   # GET /evaluations
   def index
+    @evaluations = Evaluation.order('id DESC')
+
     respond_to do |format|
       format.html # index.html.haml
-
-      # JSON format returns table views to support server-side processing, as described in
-      # http://railscasts.com/episodes/340-datatables?view=asciicast
-      format.json do
-        table = EvaluationsDatatable.new(view_context).as_json
-        table[:aaData].each do |row|
-          evaluation = row.pop
-          row << view_context.link_to('Show', evaluation, :class => 'btn')
-          row << view_context.link_to('Copy', new_evaluation_path(:based_on => evaluation.id), :class => 'btn btn-success')
-          row << view_context.link_to('Remove', evaluation, :method => :delete, :class => 'btn btn-danger',
-            :confirm => "Are you sure you want to remove this evaluation from Clockwork Raven? This does not close the evaluation or remove it from Mechanical Turk.")
-        end
-        render json: table
-      end
     end
   end
 
@@ -304,7 +292,7 @@ class EvaluationsController < ApplicationController
 
           # for components, we need to use the part of the data element that's
           # for that components
-          unless section[:type].to_s[0] == '_'
+          unless section[:type].to_s[0].chr == '_'
             section[:data] = section[:data][section[:type]]
           end
 
@@ -320,7 +308,7 @@ class EvaluationsController < ApplicationController
     end
 
     # sort
-    template.sort_by! {|section| section[:order].to_i}
+    template = template.sort_by {|section| section[:order].to_i}
 
     # update questions
     success = @evaluation.update_attributes({

--- a/app/controllers/task_responses_controller.rb
+++ b/app/controllers/task_responses_controller.rb
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'csv'
-
 class TaskResponsesController < ApplicationController
   before_filter :find_response, :except => [:index, :responses_csv]
   before_filter :require_priv, :except => [:index, :responses_csv]
@@ -33,7 +31,7 @@ class TaskResponsesController < ApplicationController
   end
 
   def responses_csv(sep = ',')
-    CSV.generate(:col_sep => sep) do |csv|
+    CSV.generate({:col_sep => sep}) do |csv|
       # Pull out the fields that were uploaded with the original data,
       # so that we can output these along with the task responses.
       orig_fields_keys = if @task_responses.empty?

--- a/app/models/evaluations_datatable.rb
+++ b/app/models/evaluations_datatable.rb
@@ -1,5 +1,5 @@
 class EvaluationsDatatable
-  delegate :params, :h, :link_to, to: :@view
+  delegate :params, :h, :link_to, :to => :@view
 
   def initialize(view)
     @view = view
@@ -7,10 +7,10 @@ class EvaluationsDatatable
 
   def as_json(options = {})
     {
-      sEcho: params[:sEcho].to_i,
-      iTotalRecords: Evaluation.count,
-      iTotalDisplayRecords: evaluations.total_entries,
-      aaData: data
+      :sEcho => params[:sEcho].to_i,
+      :iTotalRecords => Evaluation.count,
+      :iTotalDisplayRecords => evaluations.total_entries,
+      :aaData => data
     }
   end
 
@@ -62,9 +62,9 @@ private
         # Match status searches
         status = query_ids(Evaluation::STATUS_ID, term)
 
-        matched_ids = User.select('id').where("name like :search", search: search_term).map { |match| match.id }
+        matched_ids = User.select('id').where("name like :search", :search => search_term).map { |match| match.id }
         evaluations = evaluations.where("name like :search or user_id in (:uids) or prod in (:prod) or status in (:status)",
-          search: search_term, :uids => matched_ids, :prod => prod, :status => status)
+          :search => search_term, :uids => matched_ids, :prod => prod, :status => status)
       end
 
       # check for production search

--- a/app/views/evaluations/index.html.haml
+++ b/app/views/evaluations/index.html.haml
@@ -16,7 +16,7 @@
 
 = link_to 'Create New Evaluation', new_evaluation_path, :class => 'btn btn-primary'
 
-%table.table.table-striped.data-table#evaluations_table{"data-source" => evaluations_url(format: "json") }
+%table.table.table-striped.data-table#evaluations_table
   %thead
     %tr
       %th Name
@@ -28,6 +28,17 @@
       %th.empty
       %th.empty
   %tbody
+    - @evaluations.each do |evaluation|
+      %tr
+        %td= evaluation.name
+        %td= evaluation.prod? ? 'Production' : 'Sandbox'
+        %td= evaluation.status_name
+        %td= evaluation.user.name
+        %td= evaluation.created_at.in_time_zone("Pacific Time (US & Canada)").strftime(ClockworkRaven::Application::TIME_FORMAT)
+        %td= link_to 'Show', evaluation, :class => 'btn'
+        %td= link_to 'Copy', new_evaluation_path(:based_on => evaluation.id), :class => 'btn btn-success'
+        %td= link_to 'Remove', evaluation, :method => :delete, :class => 'btn btn-danger',
+          :confirm => "Are you sure you want to remove this evaluation from Clockwork Raven? This does not close the evaluation or remove it from Mechanical Turk."
 
 :javascript
   $(document).ready( function () {
@@ -36,10 +47,6 @@
         { "bSortable" : false, "aTargets" : ["empty"] }
       ],
       "sDom": "<'row-fluid'<'span6'l><'span6'f>r>t<'row-fluid'<'span6'i><'span6'p>>",
-      "bSortClasses" : false,
-      "sPaginationType": "bootstrap",
-      "bProcessing": true,
-      "bServerSide": true,
-      "sAjaxSource": $('.data-table').data('source')
+      "bSortClasses" : false
     } ).fnSort( [[4, 'desc']] );
   } );

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,7 +27,7 @@ module ClockworkRaven
   VERSION = '0.2.0'
 
   class Application < Rails::Application
-    TIME_FORMAT = "%a, %b %d, %Y %H:%M:%S %Z"
+    TIME_FORMAT = "%a, %b %d, %Y %l:%M %p"
 
     WillPaginate.per_page = 10
 

--- a/config/initializers/csv.rb
+++ b/config/initializers/csv.rb
@@ -1,0 +1,7 @@
+if RUBY_VERSION < "1.9"
+  require "rubygems"
+  require "fastercsv"
+  CSV = FCSV
+else
+  require "csv"
+end

--- a/lib/input_parser.rb
+++ b/lib/input_parser.rb
@@ -12,8 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'csv'
 require 'set'
+
+class String
+  # Taken from http://stackoverflow.com/a/4585362/231588
+  def to_my_utf8
+    if RUBY_VERSION < "1.9"
+      require 'iconv'
+      ::Iconv.conv('UTF-8//IGNORE', 'UTF-8', self + ' ')[0..-2]
+    else
+      self.force_encoding 'UTF-8'
+    end
+  end
+end
 
 module InputParser
   class << self
@@ -23,7 +34,7 @@ module InputParser
     # Throws InputParser::ParseError if the file is malformed
     def parse(file)
       type = File.extname(file.original_filename)
-      content = file.read.force_encoding 'UTF-8'
+      content = file.read.to_my_utf8
 
       begin
         case type

--- a/lib/threading.rb
+++ b/lib/threading.rb
@@ -26,7 +26,7 @@ module Threading
   #
   # If the processor throws an exception on any item, the queue is cleared,
   # and the exception is propagated.
-  def Threading.thread_pool items, size=16, retry_count=3, &processor
+  def Threading.thread_pool items, size=4, retry_count=3, &processor
     queue = Queue.new
     items.each {|o| queue.push o}
     threads = []


### PR DESCRIPTION
If you remove the factory_girl line in the Gemfile, all the code should now be compatible with Ruby 1.8.7.

Making the code 1.8.7 compatible involved:
- Removing all uses of the new hash symbol syntax (changing `{ key: value }` to `{ :key => "value" }`.
- Using FasterCSV for CSV parsing when the Ruby version is 1.8.7.
- Some changes around UTF-8 encoding.
- Removing the server-side processing for the DataTables. I couldn't quickly figure out what the bug was with server-side processing in 1.8.7, but I disliked this change anyways (there aren't that many evaluations, so it's smoother to do it client-side; this also kept on introducing a bunch of other bugs in other people's CLs; all in all, kind of a needless complication, I think), so I removed it.
