### PR TITLE
Revert "Add markdown support to the text component: fixes issue #52"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,9 +54,6 @@ gem 'resque-status'
 # UUIDs for tasks
 gem 'uuidtools'
 
-# Markdown
-gem 'rdiscount'
-
 # To use ActiveModel has_secure_password
 gem 'bcrypt-ruby', '~> 3.0.0', :require => 'bcrypt'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,6 @@ GEM
       thor (~> 0.14.6)
     raindrops (0.10.0)
     rake (0.9.2.2)
-    rdiscount (1.6.8)
     rdoc (3.12)
       json (~> 1.4)
     redis (3.0.1)
@@ -201,7 +200,6 @@ DEPENDENCIES
   net-ldap
   pry
   rails (= 3.2.1)
-  rdiscount
   resque
   resque-status
   ruby-aws

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -22,11 +22,6 @@ module TasksHelper
     string.html_safe
   end
 
-  # Renders text as markdown
-  def markdown string
-    RDiscount.new(string).to_html.html_safe
-  end
-
   # resolves data items, which can be literals, fields, or nils, to the
   # appropriate string. Fields are looked up in the fields hash
   def resolve_data data, fields

--- a/app/views/tasks/show.html.haml
+++ b/app/views/tasks/show.html.haml
@@ -39,7 +39,7 @@
         %label.error.alert.alert-error{:for => id} Please enter a response.
         %textarea{:cols => 40, :rows => 5, :name => id, :class => (fr_q.required? ? 'required' : '')}
       - when :_text
-        %div= markdown(interpolate(section[:content], @task.data))
+        %div= interpolate(section[:content], @task.data)
       - when :_header
         %h1= interpolate(section[:content], @task.data)
       - else

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -133,7 +133,6 @@ CREATE TABLE `clockwork_raven_task_responses` (
   `updated_at` timestamp NULL DEFAULT NULL,
   `mturk_assignment` varchar(255) DEFAULT NULL,
   `approved` tinyint(1) DEFAULT NULL,
-  `source` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `task_id` (`task_id`),
   CONSTRAINT `clockwork_raven_task_responses_ibfk_1` FOREIGN KEY (`task_id`) REFERENCES `clockwork_raven_tasks` (`id`)
@@ -175,9 +174,5 @@ INSERT INTO clockwork_raven_schema_migrations (version) VALUES ('20120806234641'
 INSERT INTO clockwork_raven_schema_migrations (version) VALUES ('20120807222553');
 
 INSERT INTO clockwork_raven_schema_migrations (version) VALUES ('20120810203402');
-
-INSERT INTO clockwork_raven_schema_migrations (version) VALUES ('20120911001453');
-
-INSERT INTO clockwork_raven_schema_migrations (version) VALUES ('20121010052749');
 
 INSERT INTO clockwork_raven_schema_migrations (version) VALUES ('20121020214517');

--- a/test/unit/helpers/tasks_helper_test.rb
+++ b/test/unit/helpers/tasks_helper_test.rb
@@ -28,42 +28,6 @@ class TasksHelperTest < ActionView::TestCase
     assert_equal expected_output, interpolate(template_string, data)
   end
 
-  test "markdown" do
-    input = <<-END_IN.strip_heredoc
-      <b>foo</b>
-
-      <p>blah</p>
-
-      # Things
-
-      I want some *things* and some _other things_ and some **important things**
-
-      * foo
-      * bar
-
-      <script type="text/javascript">alert('hi');</script>
-    END_IN
-
-    expected_output = <<-END_OUT.strip_heredoc
-      <p><b>foo</b></p>
-
-      <p>blah</p>
-
-      <h1>Things</h1>
-
-      <p>I want some <em>things</em> and some <em>other things</em> and some <strong>important things</strong></p>
-
-      <ul>
-      <li>foo</li>
-      <li>bar</li>
-      </ul>
-
-      <script type="text/javascript">alert('hi');</script>
-    END_OUT
-
-    assert_dom_equiv expected_output, markdown(input)
-  end
-
   test "resolve data" do
     fields = {
       'foo' => 'data1',


### PR DESCRIPTION
This reverts commit f35b88e8b90e1ea645120e9696a95e3ec8d48fd6.

I'm reverting because seems to introduce some mysterious wonkiness I haven't figured out yet...
