### PR TITLE
Make MCQuestionOption -> MCQuestionResponse a many-to-many relationship

### DIFF
--- a/app/controllers/task_responses_controller.rb
+++ b/app/controllers/task_responses_controller.rb
@@ -62,7 +62,8 @@ class TaskResponsesController < ApplicationController
 
         # MC Questions
         real_mc_questions.each do |mc_q|
-          option_id = @data[:responses][task_response.id][:mcQuestions][mc_q.id]
+          # TODO: make this aware of checkbox MCs
+          option_id = @data[:responses][task_response.id][:mcQuestions][mc_q.id][0]
           mc_q_resp = option_id.nil? ? nil : @data[:mcQuestionOptions][option_id][:label]
           row.push(mc_q_resp.nil? ? nil : mc_q_resp)
         end
@@ -88,9 +89,9 @@ class TaskResponsesController < ApplicationController
   # GET /evaluations/1/task_responses.json
   def index
     @eval = Evaluation.includes({
-      :task_responses => {:mc_question_responses => [:mc_question_option], :fr_question_responses => [], :task => [], :m_turk_user => []},
+      :task_responses => {:mc_question_responses => [:mc_question_options], :fr_question_responses => [], :task => [], :m_turk_user => []},
       :fr_questions => [:fr_question_responses],
-      :mc_questions => {:mc_question_options => [:mc_question_responses => [:mc_question_option]]}
+      :mc_questions => {:mc_question_options => [:mc_question_responses => [:mc_question_options]]}
     }).find(params[:evaluation_id])
 
     @task_responses = @eval.task_responses
@@ -165,7 +166,7 @@ class TaskResponsesController < ApplicationController
       mc_question_responses = {}
 
       resp.mc_question_responses.each do |mc_resp|
-        mc_question_responses[mc_resp.mc_question_option.mc_question_id] = mc_resp.mc_question_option_id
+        mc_question_responses[mc_resp.mc_question_options.first.mc_question_id] = mc_resp.mc_question_options.map(&:id)
       end
 
       responses[resp.id] = {

--- a/app/models/mc_question_option.rb
+++ b/app/models/mc_question_option.rb
@@ -21,7 +21,7 @@ class MCQuestionOption < ActiveRecord::Base
   before_save :clean_value
 
   belongs_to :mc_question
-  has_many :mc_question_responses, :dependent => :destroy
+  has_and_belongs_to_many :mc_question_responses
 
   validates :label, :presence => true
 

--- a/app/models/mc_question_response.rb
+++ b/app/models/mc_question_response.rb
@@ -16,7 +16,14 @@
 # Associated with the MCQuestionOption the judge chose, as well as the
 # TaskResponse, which represents the judges complete response to a task.
 class MCQuestionResponse < ActiveRecord::Base
-  belongs_to :mc_question_option
+  has_and_belongs_to_many :mc_question_options
   belongs_to :task_response
-  has_one :mc_question, :through => :mc_question_option
+
+  def mc_question
+    if self.mc_question_options.blank?
+      nil
+    else
+      self.mc_question_options.first.mc_question
+    end
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -45,7 +45,7 @@ class Task < ActiveRecord::Base
         # create a response that's linked to this task's TaskResponse and
         # the appropriate MCQuestionOption
         question_response = self.task_response.mc_question_responses.build
-        question_response.mc_question_option = opt
+        question_response.mc_question_options = [opt]
         question_response.save!
       end
     end

--- a/app/views/task_responses/index.html.haml
+++ b/app/views/task_responses/index.html.haml
@@ -176,7 +176,8 @@ Effective pay rate, based on median time: #{format_cents @eval.median_pay_rate} 
           -# We need the answers to be in the same order as the headers, so we
           -# have to look up the response by the question, becuase the questions
           -# have a stable order.
-          - option_id = @data[:responses][task_response.id][:mcQuestions][mc_q.id]
+          -# TODO: modify this logic to be aware of checkbox MC questions
+          - option_id = @data[:responses][task_response.id][:mcQuestions][mc_q.id].first
           -# check for nil in case the worker didn't submit a response to the
           -# question
           - mc_q_resp = option_id.nil? ? nil : @data[:mcQuestionOptions][option_id][:label]

--- a/db/migrate/20121120222505_create_mc_question_option_to_response_join_table.rb
+++ b/db/migrate/20121120222505_create_mc_question_option_to_response_join_table.rb
@@ -1,0 +1,10 @@
+class CreateMCQuestionOptionToResponseJoinTable < ActiveRecord::Migration
+  def change
+    create_table :mc_question_options_mc_question_responses, :id => false do |t|
+      t.references :mc_question_option, :null => false
+      t.references :mc_question_response, :null => false
+    end
+
+    add_index(:mc_question_options_mc_question_responses, [:mc_question_option_id, :mc_question_response_id], :unique => true, :name => :mc_q_opt_resp_idx)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -77,6 +77,8 @@ CREATE TABLE `clockwork_raven_m_turk_users` (
   `trusted` tinyint(1) NOT NULL DEFAULT '0',
   `banned` tinyint(1) NOT NULL DEFAULT '0',
   `prod` int(11) NOT NULL DEFAULT '0',
+  `name` varchar(255) DEFAULT NULL,
+  `notes` text,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -92,6 +94,12 @@ CREATE TABLE `clockwork_raven_mc_question_options` (
   KEY `mc_question_id` (`mc_question_id`),
   CONSTRAINT `clockwork_raven_mc_question_options_ibfk_1` FOREIGN KEY (`mc_question_id`) REFERENCES `clockwork_raven_mc_questions` (`id`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
+
+CREATE TABLE `clockwork_raven_mc_question_options_mc_question_responses` (
+  `mc_question_option_id` int(11) NOT NULL,
+  `mc_question_response_id` int(11) NOT NULL,
+  UNIQUE KEY `mc_q_opt_resp_idx` (`mc_question_option_id`,`mc_question_response_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 CREATE TABLE `clockwork_raven_mc_question_responses` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -181,3 +189,7 @@ INSERT INTO clockwork_raven_schema_migrations (version) VALUES ('20120911001453'
 INSERT INTO clockwork_raven_schema_migrations (version) VALUES ('20121010052749');
 
 INSERT INTO clockwork_raven_schema_migrations (version) VALUES ('20121020214517');
+
+INSERT INTO clockwork_raven_schema_migrations (version) VALUES ('20121107205842');
+
+INSERT INTO clockwork_raven_schema_migrations (version) VALUES ('20121120222505');

--- a/lib/m_turk_utils.rb
+++ b/lib/m_turk_utils.rb
@@ -164,7 +164,7 @@ module MTurkUtils
         props[:QualificationRequirement] = [{
           :QualificationTypeId => eval.mturk_qualification_type,
           :Comparator => 'Exists',
-          :RequiredToPreview => true          
+          :RequiredToPreview => true
         }]
       end
 
@@ -252,7 +252,7 @@ module MTurkUtils
           next if option.nil?
 
           question_response = response.mc_question_responses.build
-          question_response.mc_question_option = option
+          question_response.mc_question_options = [option]
         end
       end
 
@@ -288,7 +288,7 @@ module MTurkUtils
           next if mc_question_option.nil? or mc_question_option.mc_question.nil?
           answer_key, answer_value = mc_question_option.mc_question.label, mc_question_option.label
         end
-       
+
         next if answer_key.nil?
         answer_value = "No response given" if answer_value.nil?
         curr_answers_hash[answer_key] = answer_value

--- a/test/factories/mc_question_response.rb
+++ b/test/factories/mc_question_response.rb
@@ -14,7 +14,7 @@
 
 FactoryGirl.define do
   factory :mc_question_response do
-    mc_question_option
+    mc_question_options { [create(:mc_question_option)] }
     task_response
   end
 end

--- a/test/functional/controllers/task_responses_controller_test.rb
+++ b/test/functional/controllers/task_responses_controller_test.rb
@@ -47,10 +47,10 @@ class TaskResponsesControllerTest < ActionController::TestCase
 
     r1_mc1 = create :mc_question_response,
                     :task_response => r1,
-                    :mc_question_option => mc1_opt1
+                    :mc_question_options => [mc1_opt1]
     r1_mc2 = create :mc_question_response,
                     :task_response => r1,
-                    :mc_question_option => mc2_opt2
+                    :mc_question_options => [mc2_opt2]
     r1_fr1 = create :fr_question_response,
                     :task_response => r1,
                     :fr_question => fr1,
@@ -67,10 +67,10 @@ class TaskResponsesControllerTest < ActionController::TestCase
 
     r2_mc1 = create :mc_question_response,
                     :task_response => r2,
-                    :mc_question_option => mc1_opt2
+                    :mc_question_options => [mc1_opt2]
     r2_mc2 = create :mc_question_response,
                     :task_response => r2,
-                    :mc_question_option => mc2_opt3
+                    :mc_question_options => [mc2_opt3]
     r2_fr1 = create :fr_question_response,
                     :task_response => r2,
                     :fr_question => fr1,
@@ -87,10 +87,10 @@ class TaskResponsesControllerTest < ActionController::TestCase
 
     r3_mc1 = create :mc_question_response,
                     :task_response => r3,
-                    :mc_question_option => mc1_opt3
+                    :mc_question_options => [mc1_opt3]
     r3_mc2 = create :mc_question_response,
                     :task_response => r3,
-                    :mc_question_option => mc2_opt1
+                    :mc_question_options => [mc2_opt1]
     r3_fr1 = create :fr_question_response,
                     :task_response => r3,
                     :fr_question => fr1,
@@ -158,17 +158,17 @@ class TaskResponsesControllerTest < ActionController::TestCase
       },
       :responses => {
         r1.id => {
-          :mcQuestions => {mc1.id => mc1_opt1.id,  mc2.id => mc2_opt2.id},
+          :mcQuestions => {mc1.id => [mc1_opt1.id],  mc2.id => [mc2_opt2.id]},
           :frQuestions => {fr1.id => 'response 1', fr2.id => 'response 2'},
           :approved    => true
         },
         r2.id => {
-          :mcQuestions => {mc1.id => mc1_opt2.id,  mc2.id => mc2_opt3.id},
+          :mcQuestions => {mc1.id => [mc1_opt2.id],  mc2.id => [mc2_opt3.id]},
           :frQuestions => {fr1.id => 'response 3', fr2.id => 'response 4'},
           :approved    => false
         },
         r3.id => {
-          :mcQuestions => {mc1.id => mc1_opt3.id,  mc2.id => mc2_opt1.id},
+          :mcQuestions => {mc1.id => [mc1_opt3.id],  mc2.id => [mc2_opt1.id]},
           :frQuestions => {fr1.id => 'response 5', fr2.id => 'response 6'},
           :approved    => true
         }

--- a/test/functional/views/task_responses/index_test.rb
+++ b/test/functional/views/task_responses/index_test.rb
@@ -192,35 +192,35 @@ class TaskResponsesIndexTest < ActionController::TestCase
     @mc2_opt3.save!
 
     @r1 = create :task_response, :task => @e.tasks.first, :approved => nil, :work_duration => 10
-    create :mc_question_response, :task_response      => @r1,
-                                  :mc_question_option => @mc1_opt1
+    create :mc_question_response, :task_response       => @r1,
+                                  :mc_question_options => [@mc1_opt1]
 
-    create :mc_question_response, :task_response      => @r1,
-                                  :mc_question_option => @mc2_opt2
+    create :mc_question_response, :task_response       => @r1,
+                                  :mc_question_options => [@mc2_opt2]
 
-    create :fr_question_response, :task_response      => @r1,
-                                  :fr_question        => @fr1,
-                                  :response           => "response 1"
+    create :fr_question_response, :task_response       => @r1,
+                                  :fr_question         => @fr1,
+                                  :response            => "response 1"
 
-    create :fr_question_response, :task_response      => @r1,
-                                  :fr_question        => @fr2,
-                                  :response           => "response 2"
+    create :fr_question_response, :task_response       => @r1,
+                                  :fr_question         => @fr2,
+                                  :response            => "response 2"
 
     @r2 = create :task_response, :task => @e.tasks.second, :approved => false, :work_duration => 20
 
-    create :mc_question_response, :task_response      => @r2,
-                                  :mc_question_option => @mc1_opt2
+    create :mc_question_response, :task_response       => @r2,
+                                  :mc_question_options => [@mc1_opt2]
 
-    create :mc_question_response, :task_response      => @r2,
-                                  :mc_question_option => @mc2_opt3
+    create :mc_question_response, :task_response       => @r2,
+                                  :mc_question_options => [@mc2_opt3]
 
-    create :fr_question_response, :task_response      => @r2,
-                                  :fr_question        => @fr1,
-                                  :response           => "response 3"
+    create :fr_question_response, :task_response       => @r2,
+                                  :fr_question         => @fr1,
+                                  :response            => "response 3"
 
-    create :fr_question_response, :task_response      => @r2,
-                                  :fr_question        => @fr2,
-                                  :response           => "response 4"
+    create :fr_question_response, :task_response       => @r2,
+                                  :fr_question         => @fr2,
+                                  :response            => "response 4"
   end
 
   def get_page

--- a/test/unit/processors/close_processor_test.rb
+++ b/test/unit/processors/close_processor_test.rb
@@ -137,31 +137,29 @@ class CloseProcessorTest < ActiveSupport::TestCase
     # multiple-choice questions - assert there is a response that belongs to
     # this TaskResponse and the correct option. Check both actual questions
     # and metadata
-    assert_not_nil MCQuestionResponse.where(
-      :task_response_id => response_1.id,
-      :mc_question_option_id => mc1_1.id
+    assert_not_nil mc1_1.mc_question_responses.where(
+      :task_response_id => response_1.id
     ).first
 
-    assert_not_nil MCQuestionResponse.where(
-      :task_response_id => response_1.id,
-      :mc_question_option_id => mc2_1.id
+    assert_not_nil mc2_1.mc_question_responses.where(
+      :task_response_id => response_1.id
     ).first
 
     # metadata
-    assert_not_nil MCQuestionResponse.where(
+    assert_not_nil MCQuestion.find_by_label('metadata1').
+                              mc_question_options.
+                              where(:label => 'resp1a').
+                              first.mc_question_responses.where(
+
       :task_response_id => response_1.id,
-      :mc_question_option_id => MCQuestion.find_by_label('metadata1').
-                                           mc_question_options.
-                                           where(:label => 'resp1a').
-                                           first.id
     ).first
 
-    assert_not_nil MCQuestionResponse.where(
+    assert_not_nil MCQuestion.find_by_label('metadata2').
+                              mc_question_options.
+                              where(:label => 'resp2a').
+                              first.mc_question_responses.where(
+
       :task_response_id => response_1.id,
-      :mc_question_option_id => MCQuestion.find_by_label('metadata2').
-                                           mc_question_options.
-                                           where(:label => 'resp2a').
-                                           first.id
     ).first
 
     # free-response questions
@@ -191,31 +189,31 @@ class CloseProcessorTest < ActiveSupport::TestCase
     # multiple-choice questions - assert there is a response that belongs to
     # this TaskResponse and the correct option. Check both actual questions
     # and metadata
-    assert_not_nil MCQuestionResponse.where(
-      :task_response_id => response_2.id,
-      :mc_question_option_id => mc1_1.id
+    assert_not_nil mc1_1.mc_question_responses.where(
+      :task_response_id => response_2.id
     ).first
 
-    assert_not_nil MCQuestionResponse.where(
-      :task_response_id => response_2.id,
-      :mc_question_option_id => mc2_2.id
+    assert_not_nil mc2_2.mc_question_responses.where(
+      :task_response_id => response_2.id
     ).first
 
     # metadata
-    assert_not_nil MCQuestionResponse.where(
+    assert_not_nil MCQuestion.find_by_label('metadata1').
+                              mc_question_options.
+                              where(:label => 'resp1a').
+                              first.
+                              mc_question_responses.
+                              where(
       :task_response_id => response_2.id,
-      :mc_question_option_id => MCQuestion.find_by_label('metadata1').
-                                           mc_question_options.
-                                           where(:label => 'resp1a').
-                                           first.id
     ).first
 
-    assert_not_nil MCQuestionResponse.where(
+    assert_not_nil MCQuestion.find_by_label('metadata2').
+                              mc_question_options.
+                              where(:label => 'resp2b').
+                              first.
+                              mc_question_responses.
+                              where(
       :task_response_id => response_2.id,
-      :mc_question_option_id => MCQuestion.find_by_label('metadata2').
-                                           mc_question_options.
-                                           where(:label => 'resp2b').
-                                           first.id
     ).first
 
     # free-response questions
@@ -245,32 +243,33 @@ class CloseProcessorTest < ActiveSupport::TestCase
     # multiple-choice questions - assert there is a response that belongs to
     # this TaskResponse and the correct option. Check both actual questions
     # and metadata
-    assert_not_nil MCQuestionResponse.where(
-      :task_response_id => response_3.id,
-      :mc_question_option_id => mc1_2.id
+    assert_not_nil mc1_2.mc_question_responses.where(
+      :task_response_id => response_3.id
     ).first
 
-    assert_not_nil MCQuestionResponse.where(
-      :task_response_id => response_3.id,
-      :mc_question_option_id => mc2_1.id
+    assert_not_nil mc2_1.mc_question_responses.where(
+      :task_response_id => response_3.id
     ).first
 
     # metadata
-    assert_not_nil MCQuestionResponse.where(
+    assert_not_nil MCQuestion.find_by_label('metadata1').
+                              mc_question_options.
+                              where(:label => 'resp1b').
+                              first.
+                              mc_question_responses.
+                              where(
       :task_response_id => response_3.id,
-      :mc_question_option_id => MCQuestion.find_by_label('metadata1').
-                                           mc_question_options.
-                                           where(:label => 'resp1b').
-                                           first.id
     ).first
 
-    assert_not_nil MCQuestionResponse.where(
+    assert_not_nil MCQuestion.find_by_label('metadata2').
+                              mc_question_options.
+                              where(:label => 'resp2a').
+                              first.
+                              mc_question_responses.
+                              where(
       :task_response_id => response_3.id,
-      :mc_question_option_id => MCQuestion.find_by_label('metadata2').
-                                           mc_question_options.
-                                           where(:label => 'resp2a').
-                                           first.id
     ).first
+
 
     # free-response questions
     assert_not_nil FRQuestionResponse.where(
@@ -353,9 +352,8 @@ class CloseProcessorTest < ActiveSupport::TestCase
     # multiple-choice questions - assert there is a response that belongs to
     # this TaskResponse and the correct option. Check both actual questions
     # and metadata
-    assert_not_nil MCQuestionResponse.where(
-      :task_response_id => response_1.id,
-      :mc_question_option_id => mc1_1.id
+    assert_not_nil mc1_1.mc_question_responses.where(
+      :task_response_id => response_1.id
     ).first
 
     # task 2
@@ -368,9 +366,8 @@ class CloseProcessorTest < ActiveSupport::TestCase
     # multiple-choice questions - assert there is a response that belongs to
     # this TaskResponse and the correct option. Check both actual questions
     # and metadata
-    assert_not_nil MCQuestionResponse.where(
-      :task_response_id => response_2.id,
-      :mc_question_option_id => mc1_2.id
+    assert_not_nil mc1_2.mc_question_responses.where(
+      :task_response_id => response_2.id
     ).first
   end
 


### PR DESCRIPTION
This pull request allows an MC question response to be associated with multiple MC question options. This will allow us to implement checkbox multiple-choice questions, instead of just radio-button multiple-choice questions.
