### PR TITLE
Subdirectory mounting

### DIFF
--- a/app/assets/stylesheets/bootstrap/bootstrap.css
+++ b/app/assets/stylesheets/bootstrap/bootstrap.css
@@ -1899,7 +1899,7 @@ input[type="submit"].btn.btn-mini {
   *margin-right: .3em;
   line-height: 14px;
   vertical-align: text-top;
-  background-image: url("/assets/glyphicons-halflings.png");
+  background-image: url("../glyphicons-halflings.png");
   background-position: 14px 14px;
   background-repeat: no-repeat;
 }
@@ -1908,7 +1908,7 @@ input[type="submit"].btn.btn-mini {
   *margin-left: 0;
 }
 .icon-white {
-  background-image: url("/assets/glyphicons-halflings-white.png");
+  background-image: url("../glyphicons-halflings-white.png");
 }
 .icon-glass {
   background-position: 0      0;

--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -16,7 +16,7 @@ class LoginsController < ApplicationController
   # GET /login
   def login
     if current_user
-      redirect_to '/'
+      redirect_to root_path
     end
   end
 
@@ -34,7 +34,7 @@ class LoginsController < ApplicationController
 
       # Clear return_to so it doesn't get re-used if the user logs out and logs
       # in again.
-      target = (session[:return_to] || '/')
+      target = (session[:return_to] || root_path)
       session.delete :return_to
       redirect_to target
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,7 +21,7 @@ class UsersController < ApplicationController
   def require_password_auth
     unless AUTH_CONFIG[:type] == :password
       flash[:error] = STRINGS[:password_auth_required]
-      redirect_to '/account'
+      redirect_to account_path
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,9 +20,12 @@ module ApplicationHelper
     # empty path is :other
     return :other if request.path == ''
 
-    parts = request.path.split '/'
+    path = request.path
+    unless ClockworkRaven::Application.mounted_path.blank?
+      path = path.gsub(/^#{ClockworkRaven::Application.mounted_path}/, "")
+    end
+    parts = path.split '/'
 
-    # path = "/"
     return :evaluations if parts.length == 0
 
     # path doesn't start with /

--- a/app/views/jobs/index.html.haml
+++ b/app/views/jobs/index.html.haml
@@ -14,7 +14,7 @@
 
 %h1 Jobs
 
-= link_to "Advanced &raquo;".html_safe, '/resque', :target => '_blank'
+= link_to "Advanced &raquo;".html_safe, "#{ClockworkRaven::Application.mounted_path}/resque", :target => '_blank'
 
 %table.table
   %thead

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -21,22 +21,22 @@
     %script{:type => 'text/javascript', :src => '//www.google.com/jsapi'}
     = javascript_include_tag "application"
     = csrf_meta_tags
-    %link{:rel => 'icon', :type => 'image/png', :href => '/assets/raven.png'}
+    %link{:rel => 'icon', :type => 'image/png', :href => image_path('raven.png')}
 
   %body{:class => [controller.controller_name, controller.action_name]}
     .navbar.navbar-fixed-top
       .navbar-inner
         .container-fluid
-          %img.logo{:src => '/assets/raven-icon-32.png', :width => 32, :height => 32}
-          %a.brand{'href' => '/'}
+          %img.logo{:src => image_path('raven-icon-32.png'), :width => 32, :height => 32}
+          %a.brand{'href' => root_path}
             Clockwork Raven
             -if Rails.env == 'development'
               (Development)
           %ul.nav
             %li#evaluations_link{:class => active_in(:evaluations)}
-              %a{'href' => '/evaluations'} Evaluations
+              %a{'href' => evaluations_path} Evaluations
             %li#jobs_link{:class => active_in(:jobs)}
-              %a{'href' => '/jobs'} Background Jobs
+              %a{'href' => jobs_path} Background Jobs
             %li#accounts_link{:class => active_in(:accounts)}
               %a{'href' => account_path} My Account
           - if current_user
@@ -45,7 +45,7 @@
                 .nav-text
                   Logged in as #{current_user.username}
               %li
-                = link_to 'Log Out', '/logout', :method => 'post'
+                = link_to 'Log Out', logout_path, :method => 'post'
     .container-fluid
       .content
         = alert flash[:error], 'error'

--- a/app/views/task_responses/index.html.haml
+++ b/app/views/task_responses/index.html.haml
@@ -130,7 +130,7 @@ Effective pay rate, based on median time: #{format_cents @eval.median_pay_rate} 
                           :class => 'btn btn-danger btn-approval',
                           :data => {:response => task_response.id})
             .approval-spinner{:style => 'display:none'}
-              %img{:src => '/assets/ajax-loader.gif'}
+              %img{:src => image_path('ajax-loader.gif')}
             %div
               .clear
               -# Ban/Unban buttons
@@ -145,7 +145,7 @@ Effective pay rate, based on median time: #{format_cents @eval.median_pay_rate} 
                             :class => 'btn btn-inverse btn-unban',
                             :style => hide_if(!task_response.m_turk_user.banned))
                 .ban-spinner{:style => 'display:none'}
-                  %img{:src => '/assets/ajax-loader.gif'}
+                  %img{:src => image_path('ajax-loader.gif')}
 
               -# Trust/Untrust buttons
               .controls-wrapper
@@ -159,7 +159,7 @@ Effective pay rate, based on median time: #{format_cents @eval.median_pay_rate} 
                             :class => 'btn btn-warning btn-untrust',
                             :style => hide_if(!task_response.m_turk_user.trusted))
                 .trust-spinner{:style => 'display:none'}
-                  %img{:src => '/assets/ajax-loader.gif'}
+                  %img{:src => image_path('ajax-loader.gif')}
               .clear
 
           -# links for more info

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,10 @@ module ClockworkRaven
 
   class Application < Rails::Application
     TIME_FORMAT = "%a, %b %d, %Y %l:%M %p"
+    
+    def self.mounted_path
+      ""  # empty for root, "/dir_name" for mounted
+    end
 
     WillPaginate.per_page = 10
 
@@ -57,6 +61,8 @@ module ClockworkRaven
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
+    config.assets.prefix = "#{mounted_path}/assets"
+    
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,56 +13,58 @@
 # limitations under the License.
 
 ClockworkRaven::Application.routes.draw do
-  resources :evaluations do
-    resources :tasks
+  scope ClockworkRaven::Application.mounted_path do
+    resources :evaluations do
+      resources :tasks
 
-    member do
-      get 'original_data'
-      get 'random_task'
-      post 'submit'
-      post 'purge'
-      post 'close'
-      post 'approve_all'
-      get 'edit_template'
-      put 'update_template'
-    end
-
-    resources :task_responses do
       member do
-        post 'approve'
-        post 'reject'
+        get 'original_data'
+        get 'random_task'
+        post 'submit'
+        post 'purge'
+        post 'close'
+        post 'approve_all'
+        get 'edit_template'
+        put 'update_template'
+      end
+
+      resources :task_responses do
+        member do
+          post 'approve'
+          post 'reject'
+        end
       end
     end
-  end
 
-  resources :m_turk_users do
-    member do
-      post 'trust'
-      post 'untrust'
-      post 'ban'
-      post 'unban'
+    resources :m_turk_users do
+      member do
+        post 'trust'
+        post 'untrust'
+        post 'ban'
+        post 'unban'
+      end
     end
-  end
 
-  resources :jobs do
-    member do
-      post 'kill'
+    resources :jobs do
+      member do
+        post 'kill'
+      end
     end
+
+    # login routes
+    get "login" => "logins#login"
+    post "login" => "logins#persist_login"
+    post "logout" => "logins#logout"
+
+    # account routes
+    get 'account' => 'users#show', :as => 'account'
+    get 'account/edit' => 'users#edit', :as => 'edit_account'
+    put 'account' => 'users#update', :as => 'update_account'
+    post 'account/reset_key' => 'users#reset_key', :as => 'reset_key'
+
+    # default: /evaluations
+    root :to => 'evaluations#index'
+
+    mount Resque::Server.new, :at => "/resque"
   end
-
-  # login routes
-  get "login" => "logins#login"
-  post "login" => "logins#persist_login"
-  post "logout" => "logins#logout"
-
-  # account routes
-  get 'account' => 'users#show', :as => 'account'
-  get 'account/edit' => 'users#edit', :as => 'edit_account'
-  put 'account' => 'users#update', :as => 'update_account'
-  post 'account/reset_key' => 'users#reset_key', :as => 'reset_key'
-
-  # default: /evaluations
-  root :to => 'evaluations#index'
-
-  mount Resque::Server.new, :at => "/resque"
-end
+end 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -37,7 +37,7 @@ CREATE TABLE `clockwork_raven_fr_question_responses` (
   KEY `task_response_id` (`task_response_id`),
   CONSTRAINT `clockwork_raven_fr_question_responses_ibfk_1` FOREIGN KEY (`fr_question_id`) REFERENCES `clockwork_raven_fr_questions` (`id`),
   CONSTRAINT `clockwork_raven_fr_question_responses_ibfk_2` FOREIGN KEY (`task_response_id`) REFERENCES `clockwork_raven_task_responses` (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `clockwork_raven_fr_questions` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -50,16 +50,7 @@ CREATE TABLE `clockwork_raven_fr_questions` (
   PRIMARY KEY (`id`),
   KEY `evaluation_id` (`evaluation_id`),
   CONSTRAINT `clockwork_raven_fr_questions_ibfk_1` FOREIGN KEY (`evaluation_id`) REFERENCES `clockwork_raven_evaluations` (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
-
-CREATE TABLE `clockwork_raven_job_parts` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `job_id` int(11) DEFAULT NULL,
-  `data` text COLLATE utf8_unicode_ci,
-  `status` int(11) DEFAULT '0',
-  `error` text COLLATE utf8_unicode_ci,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `clockwork_raven_jobs` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -71,7 +62,7 @@ CREATE TABLE `clockwork_raven_jobs` (
   `resque_job` varchar(255) DEFAULT NULL,
   `processor` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `clockwork_raven_m_turk_users` (
   `id` varchar(255) NOT NULL DEFAULT '',
@@ -92,7 +83,7 @@ CREATE TABLE `clockwork_raven_mc_question_options` (
   PRIMARY KEY (`id`),
   KEY `mc_question_id` (`mc_question_id`),
   CONSTRAINT `clockwork_raven_mc_question_options_ibfk_1` FOREIGN KEY (`mc_question_id`) REFERENCES `clockwork_raven_mc_questions` (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `clockwork_raven_mc_question_responses` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -105,7 +96,7 @@ CREATE TABLE `clockwork_raven_mc_question_responses` (
   KEY `task_response_id` (`task_response_id`),
   CONSTRAINT `clockwork_raven_mc_question_responses_ibfk_1` FOREIGN KEY (`mc_question_option_id`) REFERENCES `clockwork_raven_mc_question_options` (`id`),
   CONSTRAINT `clockwork_raven_mc_question_responses_ibfk_2` FOREIGN KEY (`task_response_id`) REFERENCES `clockwork_raven_task_responses` (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `clockwork_raven_mc_questions` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -118,7 +109,7 @@ CREATE TABLE `clockwork_raven_mc_questions` (
   PRIMARY KEY (`id`),
   KEY `evaluation_id` (`evaluation_id`),
   CONSTRAINT `clockwork_raven_mc_questions_ibfk_1` FOREIGN KEY (`evaluation_id`) REFERENCES `clockwork_raven_evaluations` (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `clockwork_raven_schema_migrations` (
   `version` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
@@ -137,7 +128,7 @@ CREATE TABLE `clockwork_raven_task_responses` (
   PRIMARY KEY (`id`),
   KEY `task_id` (`task_id`),
   CONSTRAINT `clockwork_raven_task_responses_ibfk_1` FOREIGN KEY (`task_id`) REFERENCES `clockwork_raven_tasks` (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `clockwork_raven_tasks` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,

--- a/test/functional/controllers/jobs_controller_test.rb
+++ b/test/functional/controllers/jobs_controller_test.rb
@@ -112,6 +112,6 @@ class JobsControllerTest < ActionController::TestCase
 
     post :kill, :id => job.id
 
-    assert_redirected_to "/jobs/#{job.id}"
+    assert_redirected_to job_path(job)
   end
 end

--- a/test/functional/controllers/logins_controller_test.rb
+++ b/test/functional/controllers/logins_controller_test.rb
@@ -123,19 +123,19 @@ class LoginsControllerTest < ActionController::TestCase
   test "login when logged in" do
     login
     get :login
-    assert_redirected_to '/'
+    assert_redirected_to root_path
   end
 
   test "persist_login, correct auth, no return_to" do
     # test that multiple users can log in
     post :persist_login, :username => 'testuser', :password => 'foopass'
-    assert_redirected_to '/'
+    assert_redirected_to root_path
     assert_equal 'testuser', User.find(session[:user_id]).username
     assert_equal "#{STRINGS[:logged_in_prefix]} testuser", flash[:notice]
     assert_privileged
 
     post :persist_login, :username => 'joeuser', :password => 'barpass'
-    assert_redirected_to '/'
+    assert_redirected_to root_path
     assert_equal 'joeuser', User.find(session[:user_id]).username
     assert_equal "#{STRINGS[:logged_in_prefix]} joeuser", flash[:notice]
     assert_privileged
@@ -152,7 +152,7 @@ class LoginsControllerTest < ActionController::TestCase
     # test that if the user logs in again, they get redirected back to /,
     # not the previous return_to
     post :persist_login, :username => 'testuser', :password => 'foopass'
-    assert_redirected_to '/'
+    assert_redirected_to root_path
     assert_equal 'testuser', User.find(session[:user_id]).username
   end
 

--- a/test/functional/views/users/show_test.rb
+++ b/test/functional/views/users/show_test.rb
@@ -33,12 +33,12 @@ class UsersShowTest < ActionController::TestCase
   test "edit link shown iff password auth enabled" do
     with_consts :AUTH_CONFIG => {:type => :password} do
       get :show
-      assert_select "a[href='/account/edit']"
+      assert_select "a[href='#{edit_account_path}']"
     end
 
     with_consts :AUTH_CONFIG => {:type => :ldap} do
       get :show
-      assert_select_none "a[href='/account/edit']"
+      assert_select_none "a[href='#{edit_account_path}']"
     end
   end
 end

--- a/test/helpers/routing_test_helper.rb
+++ b/test/helpers/routing_test_helper.rb
@@ -13,6 +13,17 @@
 # limitations under the License.
 
 module RoutingTestHelper
+  def assert_recognizes(x, path, *args)
+    # take the mounted_path into consideration
+    mount = ClockworkRaven::Application.mounted_path
+    if path.is_a?(Hash)
+      path[:path] = "#{mount}#{path[:path]}" if path[:path]
+    else
+      path = "#{mount}#{path}" if path
+    end
+    super
+  end
+  
   def assert_resource_routed resource
     assert_routing({:method => 'get', :path => "/#{resource}"},
                    {:controller => resource, :action => 'index'})

--- a/test/integration/auth_flow_test.rb
+++ b/test/integration/auth_flow_test.rb
@@ -31,35 +31,35 @@ class AuthFlowTest < ActionDispatch::IntegrationTest
     joeuser = open_session
 
     # request protected pages
-    testuser.get_via_redirect '/jobs'
-    joeuser.get_via_redirect '/evaluations/new'
+    testuser.get_via_redirect jobs_path
+    joeuser.get_via_redirect new_evaluation_path
 
-    assert_equal '/login', testuser.path
+    assert_equal login_path, testuser.path
     assert_equal STRINGS[:not_logged_in], testuser.flash[:notice]
 
-    assert_equal '/login', joeuser.path
+    assert_equal login_path, joeuser.path
     assert_equal STRINGS[:not_logged_in], testuser.flash[:notice]
 
     # failed login, then successful login
-    testuser.post_via_redirect '/login', :username => 'noaccess', :password => 'coolpass'
-    assert_equal '/login', testuser.path
+    testuser.post_via_redirect login_path, :username => 'noaccess', :password => 'coolpass'
+    assert_equal login_path, testuser.path
     assert_equal STRINGS[:invalid_login], testuser.flash[:error]
 
-    joeuser.post_via_redirect '/login', :username => 'joeuser', :password => 'barpass'
-    assert_equal '/evaluations/new', joeuser.path
+    joeuser.post_via_redirect login_path, :username => 'joeuser', :password => 'barpass'
+    assert_equal new_evaluation_path, joeuser.path
     assert_equal "#{STRINGS[:logged_in_prefix]} joeuser", joeuser.flash[:notice]
 
-    testuser.post_via_redirect '/login', :username => 'testuser', :password => 'foopass'
-    assert_equal '/jobs', testuser.path
+    testuser.post_via_redirect login_path, :username => 'testuser', :password => 'foopass'
+    assert_equal jobs_path, testuser.path
     assert_equal "#{STRINGS[:logged_in_prefix]} testuser", testuser.flash[:notice]
 
     # joeuser now logs out and in, to make sure that return_to doesn't carry over
-    joeuser.post_via_redirect '/logout'
-    assert_equal '/login', joeuser.path
+    joeuser.post_via_redirect logout_path
+    assert_equal login_path, joeuser.path
     assert_equal STRINGS[:logged_out], joeuser.flash[:notice]
 
-    joeuser.post_via_redirect '/login', :username => 'joeuser', :password => 'barpass'
-    assert_equal '/', joeuser.path
+    joeuser.post_via_redirect login_path, :username => 'joeuser', :password => 'barpass'
+    assert_equal root_path, joeuser.path
     assert_equal "#{STRINGS[:logged_in_prefix]} joeuser", joeuser.flash[:notice]
   end
 end

--- a/test/performance/browsing_test.rb
+++ b/test/performance/browsing_test.rb
@@ -7,6 +7,6 @@ class BrowsingTest < ActionDispatch::PerformanceTest
   #                          :output => 'tmp/performance', :formats => [:flat] }
 
   def test_homepage
-    get '/'
+    get root_path
   end
 end

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -105,7 +105,7 @@ class ApplicationHelperTest < ActionView::TestCase
 
   def request
     # return a mock request
-    mock :path => (@path || '/')
+    mock :path => (@path || root_path)
   end
 
   def controller

--- a/test/unit/models/evaluations_test.rb
+++ b/test/unit/models/evaluations_test.rb
@@ -15,6 +15,10 @@
 require 'test_helper'
 
 class EvaluationsTest < ActiveSupport::TestCase
+  def evaluation_path(eval)
+    "#{ClockworkRaven::Application.mounted_path}/evaluations/#{eval.id}"
+  end
+  
   test "names must be present and unique" do
     eval = build :evaluation, :name => nil
     assert eval.invalid?, "evaluation without name was valid"
@@ -303,8 +307,8 @@ class EvaluationsTest < ActiveSupport::TestCase
              with(SubmitProcessor, task_ids, :evaluation_id => eval.id)
 
     Job.expects(:create).
-        with(:complete_url => "/evaluations/#{eval.id}",
-             :back_url     => "/evaluations/#{eval.id}",
+        with(:complete_url => evaluation_path(eval),
+             :back_url     => evaluation_path(eval),
              :title        => "Submitting Tasks").
         returns(mock_job)
 
@@ -326,8 +330,8 @@ class EvaluationsTest < ActiveSupport::TestCase
              with(CloseProcessor, task_ids, :evaluation_id => eval.id)
 
     Job.expects(:create).
-        with(:complete_url => "/evaluations/#{eval.id}",
-             :back_url     => "/evaluations/#{eval.id}",
+        with(:complete_url => evaluation_path(eval),
+             :back_url     => evaluation_path(eval),
              :title        => "Closing Tasks").
         returns(mock_job)
 
@@ -349,8 +353,8 @@ class EvaluationsTest < ActiveSupport::TestCase
              with(ApproveProcessor, task_ids, :evaluation_id => eval.id)
 
     Job.expects(:create).
-        with(:complete_url => "/evaluations/#{eval.id}",
-             :back_url     => "/evaluations/#{eval.id}",
+        with(:complete_url => evaluation_path(eval),
+             :back_url     => evaluation_path(eval),
              :title        => "Approving Tasks").
         returns(mock_job)
 
@@ -372,8 +376,8 @@ class EvaluationsTest < ActiveSupport::TestCase
              with(PurgeProcessor, task_ids, :evaluation_id => eval.id)
 
     Job.expects(:create).
-        with(:complete_url => "/evaluations/#{eval.id}",
-             :back_url     => "/evaluations/#{eval.id}",
+        with(:complete_url => evaluation_path(eval),
+             :back_url     => evaluation_path(eval),
              :title        => "Removing Tasks").
         returns(mock_job)
 


### PR DESCRIPTION
I'd like to use Clockwork Raven alongside other admin capabilities. This requires it not conflicting with those routes, so I added a the ability to mount the whole thing into a subdirectory.

```
def self.mounted_path
  "/turk"  # empty for root, "/dir_name" for mounted
end
```

Tests pass in both cases. At least the same as they were before.

I switched the tests over to use the routes helpers, which I'm not a huge fan of, but it beat adding this mounted notion all over the place.
