### PR TITLE
installation cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,19 +63,19 @@ you have marked as Trusted in Clockwork Raven.
 
        If you can't use an LDAP server, you can configure Clockwork Raven to use
        "password authentication," which will allow you to manually create
-       accounts. Copy `config/auth.example_password.yml` to `config/auth.yml`. Then,
-       you can create accounts by running "rake users:add" and change passwords
-       with `rake users:change_password`. Note that you will need to set up your
-       database (explained below) before using these rake tasks.
+       accounts. Copy `config/auth.example_password.yml` to `config/auth.yml`.
 4. Set up the database. If the databases you configured Clockwork Raven to use in
    `config/database.yml` do not exist, run `rake db:create` to create them.
    Then, run `rake db:structure:load` to load the database structure into your
    database.
-5. Start up the background workers. Just
+5. Now, you can create accounts by running "rake users:add" and change passwords
+   with `rake users:change_password`. Note that you will need to set up your
+   database (explained below) before using these rake tasks.
+6. Start up the background workers. Just
    run `rake raven:resque` to start up 4 background workers. You can start
    up more background workers by passing an argument to the rake task:
    `rake raven:resque[16]` will start up 16 background workers.
-6. Run the server. To run the server, run `rails server`.
+7. Run the server. To run the server, run `rails server`.
 
 ## Security
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,3 +1,15 @@
+CREATE TABLE `clockwork_raven_jobs` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `title` varchar(255) DEFAULT NULL,
+  `complete_url` varchar(255) NOT NULL DEFAULT '',
+  `back_url` varchar(255) NOT NULL DEFAULT '',
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  `resque_job` varchar(255) DEFAULT NULL,
+  `processor` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
+
 CREATE TABLE `clockwork_raven_evaluations` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL DEFAULT '',
@@ -24,18 +36,17 @@ CREATE TABLE `clockwork_raven_evaluations` (
   CONSTRAINT `fk_evaluations_jobs` FOREIGN KEY (`job_id`) REFERENCES `clockwork_raven_jobs` (`id`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
 
-CREATE TABLE `clockwork_raven_fr_question_responses` (
+CREATE TABLE `clockwork_raven_tasks` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `fr_question_id` int(11) unsigned NOT NULL,
-  `task_response_id` int(11) unsigned NOT NULL,
-  `response` text NOT NULL,
+  `evaluation_id` int(11) unsigned DEFAULT NULL,
+  `data` text,
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
+  `mturk_hit` varchar(255) DEFAULT NULL,
+  `uuid` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `fr_question_id` (`fr_question_id`),
-  KEY `task_response_id` (`task_response_id`),
-  CONSTRAINT `clockwork_raven_fr_question_responses_ibfk_1` FOREIGN KEY (`fr_question_id`) REFERENCES `clockwork_raven_fr_questions` (`id`),
-  CONSTRAINT `clockwork_raven_fr_question_responses_ibfk_2` FOREIGN KEY (`task_response_id`) REFERENCES `clockwork_raven_task_responses` (`id`)
+  KEY `evaluation_id` (`evaluation_id`),
+  CONSTRAINT `clockwork_raven_tasks_ibfk_1` FOREIGN KEY (`evaluation_id`) REFERENCES `clockwork_raven_evaluations` (`id`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
 
 CREATE TABLE `clockwork_raven_fr_questions` (
@@ -51,18 +62,6 @@ CREATE TABLE `clockwork_raven_fr_questions` (
   CONSTRAINT `clockwork_raven_fr_questions_ibfk_1` FOREIGN KEY (`evaluation_id`) REFERENCES `clockwork_raven_evaluations` (`id`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
 
-CREATE TABLE `clockwork_raven_jobs` (
-  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `title` varchar(255) DEFAULT NULL,
-  `complete_url` varchar(255) NOT NULL DEFAULT '',
-  `back_url` varchar(255) NOT NULL DEFAULT '',
-  `created_at` timestamp NULL DEFAULT NULL,
-  `updated_at` timestamp NULL DEFAULT NULL,
-  `resque_job` varchar(255) DEFAULT NULL,
-  `processor` varchar(255) DEFAULT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
-
 CREATE TABLE `clockwork_raven_m_turk_users` (
   `id` varchar(255) NOT NULL DEFAULT '',
   `trusted` tinyint(1) NOT NULL DEFAULT '0',
@@ -70,32 +69,6 @@ CREATE TABLE `clockwork_raven_m_turk_users` (
   `prod` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-CREATE TABLE `clockwork_raven_mc_question_options` (
-  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `mc_question_id` int(11) unsigned DEFAULT NULL,
-  `label` varchar(255) DEFAULT NULL,
-  `created_at` timestamp NULL DEFAULT NULL,
-  `updated_at` timestamp NULL DEFAULT NULL,
-  `value` int(11) DEFAULT NULL,
-  `order` int(11) DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  KEY `mc_question_id` (`mc_question_id`),
-  CONSTRAINT `clockwork_raven_mc_question_options_ibfk_1` FOREIGN KEY (`mc_question_id`) REFERENCES `clockwork_raven_mc_questions` (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
-
-CREATE TABLE `clockwork_raven_mc_question_responses` (
-  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `mc_question_option_id` int(11) unsigned DEFAULT NULL,
-  `task_response_id` int(11) unsigned DEFAULT NULL,
-  `created_at` timestamp NULL DEFAULT NULL,
-  `updated_at` timestamp NULL DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  KEY `mc_question_option_id` (`mc_question_option_id`),
-  KEY `task_response_id` (`task_response_id`),
-  CONSTRAINT `clockwork_raven_mc_question_responses_ibfk_1` FOREIGN KEY (`mc_question_option_id`) REFERENCES `clockwork_raven_mc_question_options` (`id`),
-  CONSTRAINT `clockwork_raven_mc_question_responses_ibfk_2` FOREIGN KEY (`task_response_id`) REFERENCES `clockwork_raven_task_responses` (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
 
 CREATE TABLE `clockwork_raven_mc_questions` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -108,6 +81,19 @@ CREATE TABLE `clockwork_raven_mc_questions` (
   PRIMARY KEY (`id`),
   KEY `evaluation_id` (`evaluation_id`),
   CONSTRAINT `clockwork_raven_mc_questions_ibfk_1` FOREIGN KEY (`evaluation_id`) REFERENCES `clockwork_raven_evaluations` (`id`)
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
+
+CREATE TABLE `clockwork_raven_mc_question_options` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `mc_question_id` int(11) unsigned DEFAULT NULL,
+  `label` varchar(255) DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  `value` int(11) DEFAULT NULL,
+  `order` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `mc_question_id` (`mc_question_id`),
+  CONSTRAINT `clockwork_raven_mc_question_options_ibfk_1` FOREIGN KEY (`mc_question_id`) REFERENCES `clockwork_raven_mc_questions` (`id`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
 
 CREATE TABLE `clockwork_raven_schema_migrations` (
@@ -129,17 +115,31 @@ CREATE TABLE `clockwork_raven_task_responses` (
   CONSTRAINT `clockwork_raven_task_responses_ibfk_1` FOREIGN KEY (`task_id`) REFERENCES `clockwork_raven_tasks` (`id`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
 
-CREATE TABLE `clockwork_raven_tasks` (
+CREATE TABLE `clockwork_raven_mc_question_responses` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `evaluation_id` int(11) unsigned DEFAULT NULL,
-  `data` text,
+  `mc_question_option_id` int(11) unsigned DEFAULT NULL,
+  `task_response_id` int(11) unsigned DEFAULT NULL,
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
-  `mturk_hit` varchar(255) DEFAULT NULL,
-  `uuid` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `evaluation_id` (`evaluation_id`),
-  CONSTRAINT `clockwork_raven_tasks_ibfk_1` FOREIGN KEY (`evaluation_id`) REFERENCES `clockwork_raven_evaluations` (`id`)
+  KEY `mc_question_option_id` (`mc_question_option_id`),
+  KEY `task_response_id` (`task_response_id`),
+  CONSTRAINT `clockwork_raven_mc_question_responses_ibfk_1` FOREIGN KEY (`mc_question_option_id`) REFERENCES `clockwork_raven_mc_question_options` (`id`),
+  CONSTRAINT `clockwork_raven_mc_question_responses_ibfk_2` FOREIGN KEY (`task_response_id`) REFERENCES `clockwork_raven_task_responses` (`id`)
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
+
+CREATE TABLE `clockwork_raven_fr_question_responses` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `fr_question_id` int(11) unsigned NOT NULL,
+  `task_response_id` int(11) unsigned NOT NULL,
+  `response` text NOT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fr_question_id` (`fr_question_id`),
+  KEY `task_response_id` (`task_response_id`),
+  CONSTRAINT `clockwork_raven_fr_question_responses_ibfk_1` FOREIGN KEY (`fr_question_id`) REFERENCES `clockwork_raven_fr_questions` (`id`),
+  CONSTRAINT `clockwork_raven_fr_question_responses_ibfk_2` FOREIGN KEY (`task_response_id`) REFERENCES `clockwork_raven_task_responses` (`id`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
 
 CREATE TABLE `clockwork_raven_users` (


### PR DESCRIPTION
tables need to be in a different order for the database to create cleanly.

also, cannot create users until the database is up, so re-ordered README.md to reflect this.
